### PR TITLE
Instance subscriptions are not being unsubscribed properly.

### DIFF
--- a/Rhino.ServiceBus.Tests/Bugs/When_subscribing_instance_subscriptions.cs
+++ b/Rhino.ServiceBus.Tests/Bugs/When_subscribing_instance_subscriptions.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Castle.Windsor;
+using Castle.Windsor.Configuration.Interpreters;
+using Rhino.ServiceBus.Impl;
+using Xunit;
+
+// ReSharper disable InconsistentNaming
+
+namespace Rhino.ServiceBus.Tests.Bugs
+{
+    public class When_subscribing_instance_subscriptions : MsmqTestBase
+    {
+        private static IWindsorContainer CreateContainer()
+        {
+            var container = new WindsorContainer(new XmlInterpreter());
+            container.Kernel.AddFacility("rhino.esb", new RhinoServiceBusFacility());
+            return container;
+        }
+
+        [Fact]
+        public void Should_send_AddInstanceSubscriptionMessage_on_subscribe()
+        {
+            var container = CreateContainer();
+            using (var bus = container.Resolve<IStartableServiceBus>())
+            {
+                bus.Start();
+                var consumer = new TestConsumer();
+
+                // purposefully not calling dispose on the result of this method
+                bus.AddInstanceSubscription(consumer);
+            }
+
+            var messages = testQueue2.GetAllMessages();
+            Assert.Equal(1, messages.Length);
+            Assert.Equal("Rhino.ServiceBus.Messages.AddInstanceSubscription", messages[0].Label);
+        }
+
+        [Fact]
+        public void Should_send_RemoveInstanceSubscriptionMessage_on_unsubscribe()
+        {
+            var container = CreateContainer();
+            using (var bus = container.Resolve<IStartableServiceBus>())
+            {
+                bus.Start();
+                var consumer = new TestConsumer();
+                using (bus.AddInstanceSubscription(consumer))
+                {
+                    
+                }
+            }
+
+            var messages = testQueue2.GetAllMessages();
+            Assert.Equal(2, messages.Length);
+            Assert.Equal("Rhino.ServiceBus.Messages.AddInstanceSubscription", messages[0].Label);
+            Assert.Equal("Rhino.ServiceBus.Messages.RemoveInstanceSubscription", messages[1].Label);
+        }
+
+        public class TestMessage
+        {
+            
+        }
+
+        public class TestConsumer : OccasionalConsumerOf<TestMessage>
+        {
+            public void Consume(TestMessage message)
+            {
+                // Does nothing
+            }
+        }
+    }
+}

--- a/Rhino.ServiceBus.Tests/Rhino.ServiceBus.Tests.csproj
+++ b/Rhino.ServiceBus.Tests/Rhino.ServiceBus.Tests.csproj
@@ -87,6 +87,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Bugs\Can_read_subscriptions_from_queue.cs" />
+    <Compile Include="Bugs\When_subscribing_instance_subscriptions.cs" />
     <Compile Include="Bugs\FIeldProblem_Nick.cs" />
     <Compile Include="Bugs\MsmqFlatSubscriptionsTests.cs" />
     <Compile Include="Bugs\MsmqSubQueueSubscriptionTests.cs" />

--- a/Rhino.ServiceBus/Impl/DefaultServiceBus.cs
+++ b/Rhino.ServiceBus/Impl/DefaultServiceBus.cs
@@ -285,7 +285,7 @@ namespace Rhino.ServiceBus.Impl
         {
             foreach (var message in information.ConsumedMessages)
             {
-                foreach (var owner in messageOwners.NotOf(message))
+                foreach (var owner in messageOwners.Of(message))
                 {
                 	var endpoint = endpointRouter.GetRoutedEndpoint(owner.Endpoint);
                 	endpoint.Transactional = owner.Transactional;


### PR DESCRIPTION
In DefaultServiceBus.cs, the method UnsubscribeInstanceSubscription is responsible for unsubscribing an instance subscription. The bug was that it was sending this RemoveInstanceSubscription message to message owners _not_ associated with the message, rather than message owners associated with the message.

A unit test fixture included that checks for this bug.
