### PR TITLE
Less friction: default queue permissions, host included in release, .NET 3.5 build

### DIFF
--- a/Rhino.ServiceBus/Msmq/MsmqUtil.cs
+++ b/Rhino.ServiceBus/Msmq/MsmqUtil.cs
@@ -134,10 +134,21 @@ namespace Rhino.ServiceBus.Msmq
         public static MessageQueue CreateQueue(string newQueuePath, bool transactional)
         {
 			var queue = MessageQueue.Create(newQueuePath, transactional);
-            var administratorsGroupName = new SecurityIdentifier("S-1-5-32-544")
-                                                .Translate(typeof(NTAccount))
-                                                .ToString();
+
+            var administratorsGroupName = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null)
+                .Translate(typeof(NTAccount))
+                .ToString();
+            var everyoneGroupName = new SecurityIdentifier(WellKnownSidType.WorldSid, null)
+                .Translate(typeof(NTAccount))
+                .ToString();
+            var anonymousLogonName = new SecurityIdentifier(WellKnownSidType.AnonymousSid, null)
+                .Translate(typeof(NTAccount))
+                .ToString();
+
             queue.SetPermissions(administratorsGroupName, MessageQueueAccessRights.FullControl, AccessControlEntryType.Allow);
+            queue.SetPermissions(everyoneGroupName, MessageQueueAccessRights.WriteMessage, AccessControlEntryType.Allow);
+            queue.SetPermissions(anonymousLogonName, MessageQueueAccessRights.WriteMessage, AccessControlEntryType.Allow);
+
             return queue;
         }
         

--- a/build_release_3.5.ps1
+++ b/build_release_3.5.ps1
@@ -1,0 +1,3 @@
+import-module .\psake.psm1
+invoke-psake -framework '3.5' .\default.ps1 -properties @{config='Release';target_framework_version='3.5'}
+remove-module psake

--- a/default.ps1
+++ b/default.ps1
@@ -101,6 +101,7 @@ task Release  -depends Test{
     	$build_dir\Rhino.Queues.dll `
     	$build_dir\Rhino.ServiceBus.dll `
     	$build_dir\Rhino.ServiceBus.xml `
+    	$build_dir\Rhino.ServiceBus.Host.exe `
     	$build_dir\Wintellect.Threading.dll `
     	$build_dir\Wintellect.Threading.xml `
     	license.txt `


### PR DESCRIPTION
- added build script for .NET 3.5
- updated default build to include the host exe in release output
- included send permissions for 'Everyone' and 'Anonymous' for newly created queues (this is in addition to the Administrators group and current executing user getting full permissions) Less configuration and changes to get up and running.
