### PR TITLE
MSMQ permissions, release build output update

### DIFF
--- a/Rhino.ServiceBus/Msmq/MsmqUtil.cs
+++ b/Rhino.ServiceBus/Msmq/MsmqUtil.cs
@@ -134,10 +134,21 @@ namespace Rhino.ServiceBus.Msmq
         public static MessageQueue CreateQueue(string newQueuePath, bool transactional)
         {
 			var queue = MessageQueue.Create(newQueuePath, transactional);
-            var administratorsGroupName = new SecurityIdentifier("S-1-5-32-544")
-                                                .Translate(typeof(NTAccount))
-                                                .ToString();
+
+            var administratorsGroupName = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null)
+                .Translate(typeof(NTAccount))
+                .ToString();
+            var everyoneGroupName = new SecurityIdentifier(WellKnownSidType.WorldSid, null)
+                .Translate(typeof(NTAccount))
+                .ToString();
+            var anonymousLogonName = new SecurityIdentifier(WellKnownSidType.AnonymousSid, null)
+                .Translate(typeof(NTAccount))
+                .ToString();
+
             queue.SetPermissions(administratorsGroupName, MessageQueueAccessRights.FullControl, AccessControlEntryType.Allow);
+            queue.SetPermissions(everyoneGroupName, MessageQueueAccessRights.WriteMessage, AccessControlEntryType.Allow);
+            queue.SetPermissions(anonymousLogonName, MessageQueueAccessRights.WriteMessage, AccessControlEntryType.Allow);
+            
             return queue;
         }
         

--- a/default.ps1
+++ b/default.ps1
@@ -101,6 +101,7 @@ task Release  -depends Test{
     	$build_dir\Rhino.Queues.dll `
     	$build_dir\Rhino.ServiceBus.dll `
     	$build_dir\Rhino.ServiceBus.xml `
+    	$build_dir\Rhino.ServiceBus.Host.exe `
     	$build_dir\Wintellect.Threading.dll `
     	$build_dir\Wintellect.Threading.xml `
     	license.txt `


### PR DESCRIPTION
Let's try this again...
- Default MSMQ queue permissions now include SendMessage rights for Everyone and Anonymous
- Added Rhino.ServiceBus.Host.exe to release output

Thanks!
Matt
