### PR TITLE
Ioc bugfix

### DIFF
--- a/Rhino.ServiceBus.StructureMap/StructureMapBootStrapper.cs
+++ b/Rhino.ServiceBus.StructureMap/StructureMapBootStrapper.cs
@@ -40,16 +40,21 @@ namespace Rhino.ServiceBus.StructureMap
             ConfigureContainer();
         }
 
-        protected virtual void ConfigureContainer()
-        {
-            container.Configure(c => c.Scan(s =>
-            {
-                s.Assembly(typeof(StructureMapBootStrapper).Assembly);
-                s.AddAllTypesOf(typeof(IMessageConsumer)).NameBy(t => t.FullName);
-                s.Exclude(t => typeof(IOccasionalMessageConsumer).IsAssignableFrom(t) == false);
-                s.AddAllTypesOf<IDeploymentAction>();
-                s.AddAllTypesOf<IEnvironmentValidationAction>();
-            }));
+        protected virtual void ConfigureContainer() {
+          container.Configure(c => {
+            c.Scan(s => {
+                      s.Assembly(typeof(IServiceBus).Assembly);
+                      s.AddAllTypesOf<IMessageConsumer>().NameBy(t => t.FullName);
+                      s.Exclude(t => typeof(IOccasionalMessageConsumer).IsAssignableFrom(t) == true);
+                    });
+            c.Scan(s => {
+                      s.Assembly(GetType().Assembly);
+                      s.AddAllTypesOf<IMessageConsumer>().NameBy(t => t.FullName);
+                      s.Exclude(t => typeof(IOccasionalMessageConsumer).IsAssignableFrom(t) == true);
+                      s.AddAllTypesOf<IDeploymentAction>();
+                      s.AddAllTypesOf<IEnvironmentValidationAction>();
+                    });
+          });
         }
 
         public override void ExecuteDeploymentActions(string user)

--- a/Rhino.ServiceBus.StructureMap/StructureMapBuilder.cs
+++ b/Rhino.ServiceBus.StructureMap/StructureMapBuilder.cs
@@ -78,7 +78,6 @@ namespace Rhino.ServiceBus.StructureMap
             var busConfig = (RhinoServiceBusConfiguration) config;
             container.Configure(c =>
             {
-                c.For<IDeploymentAction>().Use<CreateLogQueueAction>();
                 c.For<IDeploymentAction>().Use<CreateQueuesAction>();
                 c.For<IStartableServiceBus>().Singleton().Use<DefaultServiceBus>()
                     .Ctor<MessageOwner[]>().Is(busConfig.MessageOwners.ToArray());
@@ -138,8 +137,12 @@ namespace Rhino.ServiceBus.StructureMap
 
         public void RegisterLoggingEndpoint(Uri logEndpoint)
         {
-            container.Configure(c => c.For<MessageLoggingModule>().Singleton().Use<MessageLoggingModule>()
-                                         .Ctor<Uri>().Is(logEndpoint));
+          container.Configure(c =>
+          {
+            c.For<MessageLoggingModule>().Singleton().Use<MessageLoggingModule>()
+              .Ctor<Uri>().Is(logEndpoint);
+            c.For<IDeploymentAction>().Use<CreateLogQueueAction>();
+          });
         }
 
         public void RegisterMsmqTransport(Type queueStrategyType)


### PR DESCRIPTION
StructureMapBootStrapper.ConfigureContainer: does now register standard consumers of the IServiceBus assembly. does not register any DeploymentActions of the RhinoServiceBus-assembly anymore. So there are no exceptions in the execution of the DeployAction anymore. Each DeploymentAction is only registered if its corresponding config section is defined.
