### PR TITLE
Notify/Publish works when subscribed by base type or interface.

### DIFF
--- a/Rhino.ServiceBus/Impl/DefaultServiceBus.cs
+++ b/Rhino.ServiceBus/Impl/DefaultServiceBus.cs
@@ -357,9 +357,15 @@ namespace Rhino.ServiceBus.Impl
             var subscriptions = new HashSet<Uri>();
             foreach (var message in messages)
             {
-                foreach (var uri in subscriptionStorage.GetSubscriptionsFor(message.GetType()))
+                Type messageType = message.GetType();
+                while (messageType != null)
                 {
-                    subscriptions.Add(uri);
+                    subscriptions.UnionWith(subscriptionStorage.GetSubscriptionsFor(messageType));
+                    foreach (Type interfaceType in messageType.GetInterfaces())
+                    {
+                        subscriptions.UnionWith(subscriptionStorage.GetSubscriptionsFor(interfaceType));
+                    }
+                    messageType = messageType.BaseType;
                 }
             }
             foreach (Uri subscription in subscriptions)


### PR DESCRIPTION
Subscriptions are already stored for consumers like `ConsumerOf<IMessageInterface>`, so I added support to `Notify` or `Publish` to those subscriptions.
