### PR TITLE
Unity Container Support LoadBalancer final

### DIFF
--- a/Rhino.ServiceBus.Tests/Containers/Unity/ContainerTests.cs
+++ b/Rhino.ServiceBus.Tests/Containers/Unity/ContainerTests.cs
@@ -93,7 +93,7 @@ namespace Rhino.ServiceBus.Tests.Containers.Unity
                 .UseStandaloneConfigurationFile("BusWithLogging.config")
                 .Configure();
 
-            var loggingModule = container.Resolve<MessageLoggingModule>();
+            var loggingModule = container.Resolve<MessageLoggingModule>(typeof(MessageLoggingModule).FullName);
             Assert.NotNull(loggingModule);
         }
 
@@ -106,7 +106,7 @@ namespace Rhino.ServiceBus.Tests.Containers.Unity
                 .UseStandaloneConfigurationFile("LoadBalancer/BusWithLoadBalancer.config")
                 .Configure();
 
-            var loadBalancerMessageModule = container.Resolve<LoadBalancerMessageModule>();
+            var loadBalancerMessageModule = container.Resolve<LoadBalancerMessageModule>(typeof(LoadBalancerMessageModule).FullName);
             Assert.NotNull(loadBalancerMessageModule);
         }
     }

--- a/Rhino.ServiceBus.Unity/ConsumerExtension.cs
+++ b/Rhino.ServiceBus.Unity/ConsumerExtension.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Microsoft.Practices.Unity;
+﻿using Microsoft.Practices.Unity;
 using Rhino.ServiceBus.Config;
 using Rhino.ServiceBus.Internal;
 

--- a/Rhino.ServiceBus.Unity/UnityBuilder.cs
+++ b/Rhino.ServiceBus.Unity/UnityBuilder.cs
@@ -52,10 +52,11 @@ namespace Rhino.ServiceBus.Unity
                 configurationAware.Configure(config, this);
             }
 
-            foreach (var type in config.MessageModules)
+            foreach (var messageModule in config.MessageModules)
             {
-                if (!container.IsRegistered(type))
-                    container.RegisterType(type, type.FullName);
+                Type module = messageModule;
+                if (!container.IsRegistered(module))
+                    container.RegisterType(typeof(IMessageModule), module, module.FullName, new ContainerControlledLifetimeManager());
             }
 
             container.RegisterType<IReflection, DefaultReflection>(new ContainerControlledLifetimeManager());
@@ -142,7 +143,7 @@ namespace Rhino.ServiceBus.Unity
 
         public void RegisterLoadBalancerEndpoint(Uri loadBalancerEndpoint)
         {
-            container.RegisterType<IMessageModule, LoadBalancerMessageModule>(
+            container.RegisterType<LoadBalancerMessageModule>(typeof(LoadBalancerMessageModule).FullName,
                 new ContainerControlledLifetimeManager(),
                 new InjectionConstructor(
                     new InjectionParameter<Uri>(loadBalancerEndpoint),
@@ -151,7 +152,7 @@ namespace Rhino.ServiceBus.Unity
 
         public void RegisterLoggingEndpoint(Uri logEndpoint)
         {
-            container.RegisterType<IMessageModule, MessageLoggingModule>(
+            container.RegisterType<MessageLoggingModule>(typeof(MessageLoggingModule).FullName,
                 new ContainerControlledLifetimeManager(),
                 new InjectionConstructor(
                     new ResolvedParameter<IEndpointRouter>(),


### PR DESCRIPTION
I have finally managed to fix the loadbalancer issue. The first fix (which I can see you have merged) caused the DefaultServiceBus to be resolved without the LoadBalancerMessageModule. The fix in this pull request should fix that.
