### PR TITLE
IReflection methods connected with xml serialization rename

### DIFF
--- a/Rhino.ServiceBus.Tests/DefaultReflectionTests.cs
+++ b/Rhino.ServiceBus.Tests/DefaultReflectionTests.cs
@@ -15,8 +15,8 @@ namespace Rhino.ServiceBus.Tests
         public void Can_roundtrip_uri()
         {
             object msg = new Uri("http://ayende.com");
-            var typeName = reflection.GetAssemblyQualifiedNameWithoutVersion(msg.GetType());
-            var type = reflection.GetType(typeName);
+            var typeName = reflection.GetNamespaceForXml(msg.GetType());
+            var type = reflection.GetTypeFromXmlNamespace(typeName);
             Assert.NotNull(type);
         }
 
@@ -68,14 +68,14 @@ namespace Rhino.ServiceBus.Tests
         public void Gets_assembly_name_without_version_for_generic_lists()
         {
             var list = new List<SomeMsg>();
-            var output = reflection.GetAssemblyQualifiedNameWithoutVersion(list.GetType());
+            var output = reflection.GetNamespaceForXml(list.GetType());
 
             Assert.DoesNotContain("Rhino.ServiceBus.Tests,Version=", output.Replace(" ", ""));
         }
         [Fact]
         public void Gets_assembly_name_without_version_for_generic_types_in_local_assemblies()
         {
-            var output = reflection.GetAssemblyQualifiedNameWithoutVersion(typeof(GenericConsumer<SomeMsg>));
+            var output = reflection.GetNamespaceForXml(typeof(GenericConsumer<SomeMsg>));
 
             Assert.DoesNotContain("Rhino.ServiceBus.Tests,Version=", output.Replace(" ", ""));
             Assert.NotNull(Type.GetType(output));  // still fail!!!
@@ -84,7 +84,7 @@ namespace Rhino.ServiceBus.Tests
         [Fact]
         public void Gets_assembly_name_with_more_than_one_type_parameter()
         {
-            string name = reflection.GetAssemblyQualifiedNameWithoutVersion(typeof(Dictionary<object, object>));
+            string name = reflection.GetNamespaceForXml(typeof(Dictionary<object, object>));
             Assert.Equal(
                 typeof(Dictionary<object, object>).AssemblyQualifiedName,
                 name);
@@ -94,7 +94,7 @@ namespace Rhino.ServiceBus.Tests
         [Fact]
         public void Gets_assembly_name_without_version_for_generic_types_with_more_than_one_type_parameter_in_local_assemblies()
         {
-            string name = reflection.GetAssemblyQualifiedNameWithoutVersion(typeof(TestDictionary<string, string>));
+            string name = reflection.GetNamespaceForXml(typeof(TestDictionary<string, string>));
             var type = Type.GetType(name);
             Assert.NotNull(type);   // fail if not apply my fix!!!
         }

--- a/Rhino.ServiceBus/Impl/DefaultReflection.cs
+++ b/Rhino.ServiceBus/Impl/DefaultReflection.cs
@@ -64,16 +64,16 @@ namespace Rhino.ServiceBus.Impl
             }
         }
 
-        public Type GetType(string type)
+        public Type GetTypeFromXmlNamespace(string xmlNamespace)
         {
             Type value;
-            if (wellKnownTypeNameToType.TryGetValue(type, out value))
+            if (wellKnownTypeNameToType.TryGetValue(xmlNamespace, out value))
                 return value;
-            if(type.StartsWith("array_of_"))
+            if(xmlNamespace.StartsWith("array_of_"))
             {
-                return GetType(type.Substring("array_of_".Length));
+                return GetTypeFromXmlNamespace(xmlNamespace.Substring("array_of_".Length));
             }
-            return Type.GetType(type);
+            return Type.GetType(xmlNamespace);
         }
 
         public void InvokeAdd(object instance, object item)
@@ -288,18 +288,18 @@ namespace Rhino.ServiceBus.Impl
             typeName = typeName.Substring(0, indexOf) + "_of_";
             foreach (var argument in type.GetGenericArguments())
             {
-                typeName += GetNamespaceForXml(argument) + "_";
+                typeName += GetNamespacePrefixForXml(argument) + "_";
             }
             return typeName.Substring(0, typeName.Length - 1);
         }
 
-        public string GetNamespaceForXml(Type type)
+        public string GetNamespacePrefixForXml(Type type)
         {
             string value;
             if(typeToWellKnownTypeName.TryGetValue(type, out value))
                 return value;
             if (type.IsArray)
-                return "array_of_" + GetNamespaceForXml(type.GetElementType());
+                return "array_of_" + GetNamespacePrefixForXml(type.GetElementType());
 
             if (type.Namespace == null && type.Name.StartsWith("<>"))
                 throw new InvalidOperationException("Anonymous types are not supported");
@@ -317,13 +317,13 @@ namespace Rhino.ServiceBus.Impl
             typeName = typeName.Substring(0, indexOf)+ "_of_";
             foreach (var argument in type.GetGenericArguments())
             {
-                typeName += GetNamespaceForXml(argument) + "_";
+                typeName += GetNamespacePrefixForXml(argument) + "_";
             }
             return typeName.Substring(0,typeName.Length-1);
         }
 
 
-        public string GetAssemblyQualifiedNameWithoutVersion(Type type)
+        public string GetNamespaceForXml(Type type)
         {
             string value;
             if (typeToWellKnownTypeName.TryGetValue(type, out value))
@@ -339,7 +339,7 @@ namespace Rhino.ServiceBus.Impl
                     .Append("[")
                     .Append(String.Join(",",
                                     type.GetGenericArguments()
-                                        .Select(t => "[" + GetAssemblyQualifiedNameWithoutVersion(t) + "]")
+                                        .Select(t => "[" + GetNamespaceForXml(t) + "]")
                                         .ToArray()))
                     .Append("], ");
                 if (assembly.GlobalAssemblyCache)

--- a/Rhino.ServiceBus/Internal/IReflection.cs
+++ b/Rhino.ServiceBus/Internal/IReflection.cs
@@ -34,15 +34,15 @@ namespace Rhino.ServiceBus.Internal
 
 		object InvokeSagaFinderFindBy(object sagaFinder, object msg);
 
-        string GetNamespaceForXml(Type type);
+        string GetNamespacePrefixForXml(Type type);
 
-        string GetAssemblyQualifiedNameWithoutVersion(Type type);
+        string GetNamespaceForXml(Type type);
 
         IEnumerable<string> GetProperties(object value);
 
         object Get(object instance, string name);
 
-        Type GetType(string type);
+        Type GetTypeFromXmlNamespace(string xmlNamespace);
 
         void InvokeAdd(object instance, object item);
 


### PR DESCRIPTION
Hi,

Here is a patch with renames of methods on IReflection connected to xml serialization to be more xml centric, this way I can be sure that my custom implementation of IReflection will not break other parts of RSB in future, other than xml serialization:)
- GetType is now GetTypeFromXmlNamespace
- GetAssemblyQualifiedNameWithoutVersion is now GetNamespaceForXml
- GetNamespaceForXml is now GetNamespacePrefixForXml

In my project I created custom implementations of IReflection.GetAssemblyQualifiedNameWithoutVersion and IReflection.GetType, to change the way RSB serialize messages to xml. Both methods are used only in XmlMessageSerializer, first to create xml namespace for given type, second to recreate type from such xml namespace. I needed my custom implementation because, giving example, we have Service project with messages, and Client project, that instead of referencing to Service.dll, compile those message into its own assembly. The problem was that serialization on Client sets xml namespaces to something like "Service.Feature.MyMessage, Client", but on Service during deserialization expected type would be "Service.Feature.MyMessage, **Service**", and other way around: message send from Service will have namespace pointing to Service.dll, but Client have those messages in Client.dll.
