### PR TITLE
One way bus auto port selection

### DIFF
--- a/Rhino.ServiceBus.Tests/CanSendMsgsFromOneWayBusUsingRhinoQueues.cs
+++ b/Rhino.ServiceBus.Tests/CanSendMsgsFromOneWayBusUsingRhinoQueues.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading;
 using Castle.MicroKernel.Registration;
 using Castle.Windsor;
+using Rhino.ServiceBus.Hosting;
 using Rhino.ServiceBus.Impl;
 using Rhino.ServiceBus.Internal;
 using Rhino.ServiceBus.RhinoQueues;
@@ -19,6 +20,8 @@ namespace Rhino.ServiceBus.Tests
         {
             if (Directory.Exists("one_way.esent"))
                 Directory.Delete("one_way.esent", true);
+            if (Directory.Exists("one_way2.esent"))
+                Directory.Delete("one_way2.esent", true);
             if (Directory.Exists("test_queue.esent"))
                 Directory.Delete("test_queue.esent", true);
             if (Directory.Exists("test_queue_subscriptions.esent"))
@@ -29,8 +32,13 @@ namespace Rhino.ServiceBus.Tests
                 .UseStandaloneConfigurationFile("ReceiveOneWayBusRhinoQueues.config")
                 .Configure();
             container.Register(Component.For<StringConsumer>());
+            container.Register(Component.For<IntConsumer>());
             StringConsumer.Value = null;
             StringConsumer.Event = new ManualResetEvent(false);
+
+            IntConsumer.Count = 0;
+            IntConsumer.Total = 0;
+            IntConsumer.Event = new ManualResetEvent(false);
         }
 
 
@@ -42,14 +50,14 @@ namespace Rhino.ServiceBus.Tests
             {
                 bus.Start();
 
-                using (var oneWay = new RhinoQueuesOneWayBus(new[]
-                                                 {
+                using (var oneWay = new RhinoQueuesOneWayBus(
+                                                new[]{
                                                      new MessageOwner
                                                          {
                                                              Endpoint = bus.Endpoint.Uri,
                                                              Name = "System",
                                                          },
-                                                 }, 
+                                                    }, 
                                                  container.Resolve<IMessageSerializer>(),
                                                  Path.Combine(Path.GetFullPath(AppDomain.CurrentDomain.BaseDirectory), "one_way.esent"),
                                                  false,
@@ -87,6 +95,48 @@ namespace Rhino.ServiceBus.Tests
             }
         }
 
+        [Fact]
+        public void CanRunTwoOneWayBusesOnSameMachine()
+        {
+            using (var bus = container.Resolve<IStartableServiceBus>())
+            {
+                bus.Start();
+
+                var config1 = new RhinoQueuesHostConfiguration()
+                    .Receive("System.Int", "rhino.queues://localhost/test_queue");
+                
+                //Must specify an alternate storage path since we are running both out of same base directory.
+                var config2 = new RhinoQueuesHostConfiguration()
+                    .StoragePath(Path.Combine(Path.GetFullPath(AppDomain.CurrentDomain.BaseDirectory), "one_way2.esent"))
+                    .Receive("System.Int", "rhino.queues://localhost/test_queue");
+                
+
+                using (var c1 = new WindsorContainer())
+                using (var c2 = new WindsorContainer())
+                {
+                    new OnewayRhinoServiceBusConfiguration()
+                        .UseCastleWindsor(c1)
+                        .UseConfiguration(config1.ToBusConfiguration())
+                        .Configure();
+
+                    new OnewayRhinoServiceBusConfiguration()
+                        .UseCastleWindsor(c2)
+                        .UseConfiguration(config2.ToBusConfiguration())
+                        .Configure();
+
+                    var onewayBus1 = c1.Resolve<IOnewayBus>();
+                    var onewayBus2 = c2.Resolve<IOnewayBus>();
+
+                    onewayBus1.Send(1);
+                    onewayBus2.Send(2);
+
+                    IntConsumer.Event.WaitOne(TimeSpan.FromSeconds(3));
+                    Assert.Equal(2, IntConsumer.Count);
+                    Assert.Equal(3, IntConsumer.Total);
+                }
+            }
+        }
+
         public class StringConsumer : ConsumerOf<string>
         {
             public static ManualResetEvent Event;
@@ -96,6 +146,19 @@ namespace Rhino.ServiceBus.Tests
             {
                 Value = pong;
                 Event.Set();
+            }
+        }
+
+        public class IntConsumer : ConsumerOf<int>
+        {
+            public static ManualResetEvent Event;
+            public static int Total;
+            public static int Count;
+            public void Consume(int pong)
+            {
+                Total += pong;
+                Count++;
+                if(Count == 2) Event.Set();
             }
         }
 

--- a/Rhino.ServiceBus/RhinoQueues/RhinoQueuesOneWayBus.cs
+++ b/Rhino.ServiceBus/RhinoQueues/RhinoQueuesOneWayBus.cs
@@ -10,7 +10,7 @@ namespace Rhino.ServiceBus.RhinoQueues
     public class RhinoQueuesOneWayBus : RhinoQueuesTransport,IOnewayBus
     {
         private MessageOwnersSelector messageOwners;
-        public static readonly Uri NullEndpoint = new Uri("null://nowhere:24689/middle");
+        public static readonly Uri NullEndpoint = new Uri(string.Format("null://nowhere:{0}/middle", ANY_AVAILABLE_PORT));
         public RhinoQueuesOneWayBus(MessageOwner[] messageOwners, IMessageSerializer messageSerializer, string path, bool enablePerformanceCounters, IMessageBuilder<MessagePayload> messageBuilder)
             : base(NullEndpoint, new EndpointRouter(), messageSerializer, 1, path, IsolationLevel.ReadCommitted, 5, enablePerformanceCounters, messageBuilder)
 

--- a/Rhino.ServiceBus/RhinoQueues/RhinoQueuesTransport.cs
+++ b/Rhino.ServiceBus/RhinoQueues/RhinoQueuesTransport.cs
@@ -26,7 +26,7 @@ namespace Rhino.ServiceBus.RhinoQueues
     {
         public const int ANY_AVAILABLE_PORT = 9; //This is the Discard Protocol port.  No bus should ever listen on it, so we will use it for our marker port.
 
-        private readonly Uri endpoint;
+        private Uri endpoint;
         private readonly IEndpointRouter endpointRouter;
         private readonly IMessageSerializer messageSerializer;
         private readonly int threadCount;
@@ -148,7 +148,11 @@ namespace Rhino.ServiceBus.RhinoQueues
                 port = 2200;
 
             if (port == ANY_AVAILABLE_PORT)
+            {
                 ConfigureAndStartPortManagerOnAnyAvailablePort();
+                port = queueManager.Endpoint.Port;
+                endpoint = new Uri(endpoint.OriginalString.Replace(endpoint.Host + ":" + ANY_AVAILABLE_PORT, endpoint.Host + ":" + port));
+            }
             else
                 ConfigureAndStartQueueManager(port);
 


### PR DESCRIPTION
Per discussion in the forum, here is the code for auto-port selection.  Here are some concerns I have.

1) Commit 32341ecc2488ffed8ed872ed1ccec57a04d356cd added handling for the possible case that another process opens the port between the time the port is selected and the time it is opened.  I think its a bit of a messy approach in that the QueueManager needs to be thrown out and a new one created when this happens.  I think it would be better to update RQ to support auto port selection and then push retry functionality down into RQ.  As this is a pretty out there edge case I can live with the current implementation for now if you can.

I did not provide a covering test for the scenario as it wasn't clear to me how to simulate the situation.

2) Commit 559a8ad3c76ffe83c5b3408644befab83f346d48 updates the bus's/transports end point to reflect the port selected.  I am not sure if this is really need but is seemed like a good idea.  Again I did not provide a covering test for this but I can if you wish.

Lastly, of course, I still have broken tests on my end but its the same tests in the branch and in master.
