### PR TITLE
Oneway bus name/path missmatch fix

### DIFF
--- a/Rhino.ServiceBus.Autofac/AutofacBuilder.cs
+++ b/Rhino.ServiceBus.Autofac/AutofacBuilder.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Messaging;
 using Autofac;
@@ -220,11 +219,11 @@ namespace Rhino.ServiceBus.Autofac
             builder.Update(container);
         }
 
-        public void RegisterRhinoQueuesTransport(string path, string name, bool enablePerformanceCounters)
+        public void RegisterRhinoQueuesTransport(string path, bool enablePerformanceCounters)
         {
             var builder = new ContainerBuilder();
             builder.RegisterType<PhtSubscriptionStorage>()
-                .WithParameter("subscriptionPath", Path.Combine(path, name + "_subscriptions.esent"))
+                .WithParameter("subscriptionPath", path + "_subscriptions.esent")
                 .As<ISubscriptionStorage>()
                 .SingleInstance();
             builder.RegisterType<RhinoQueuesTransport>()
@@ -232,7 +231,7 @@ namespace Rhino.ServiceBus.Autofac
                 .WithParameter("endpoint", config.Endpoint)
                 .WithParameter("queueIsolationLevel", config.IsolationLevel)
                 .WithParameter("numberOfRetries", config.NumberOfRetries)
-                .WithParameter("path", Path.Combine(path, name + ".esent"))
+                .WithParameter("path", path + ".esent")
                 .WithParameter("enablePerformanceCounters", enablePerformanceCounters)
                 .As<ITransport>()
                 .SingleInstance();
@@ -252,7 +251,7 @@ namespace Rhino.ServiceBus.Autofac
                 .SingleInstance();
             builder.RegisterType<RhinoQueuesOneWayBus>()
                 .WithParameter("messageOwners", oneWayConfig.MessageOwners)
-                .WithParameter("path", Path.Combine(busConfig.Path, "one_way.esent"))
+                .WithParameter("path", busConfig.ConstructedPath + ".esent")
                 .WithParameter("enablePerformanceCounters", busConfig.EnablePerformanceCounters)
                 .As<IOnewayBus>()
                 .SingleInstance();

--- a/Rhino.ServiceBus.Autofac/AutofacBuilder.cs
+++ b/Rhino.ServiceBus.Autofac/AutofacBuilder.cs
@@ -219,11 +219,12 @@ namespace Rhino.ServiceBus.Autofac
             builder.Update(container);
         }
 
-        public void RegisterRhinoQueuesTransport(string queuePath, string subscriptionPath, bool enablePerformanceCounters)
+        public void RegisterRhinoQueuesTransport()
         {
+            var busConfig = config.ConfigurationSection.Bus;
             var builder = new ContainerBuilder();
             builder.RegisterType<PhtSubscriptionStorage>()
-                .WithParameter("subscriptionPath", subscriptionPath)
+                .WithParameter("subscriptionPath", busConfig.SubscriptionPath)
                 .As<ISubscriptionStorage>()
                 .SingleInstance();
             builder.RegisterType<RhinoQueuesTransport>()
@@ -231,8 +232,8 @@ namespace Rhino.ServiceBus.Autofac
                 .WithParameter("endpoint", config.Endpoint)
                 .WithParameter("queueIsolationLevel", config.IsolationLevel)
                 .WithParameter("numberOfRetries", config.NumberOfRetries)
-                .WithParameter("path", queuePath)
-                .WithParameter("enablePerformanceCounters", enablePerformanceCounters)
+                .WithParameter("path", busConfig.QueuePath)
+                .WithParameter("enablePerformanceCounters", busConfig.EnablePerformanceCounters)
                 .As<ITransport>()
                 .SingleInstance();
             builder.RegisterType<RhinoQueuesMessageBuilder>()

--- a/Rhino.ServiceBus.Autofac/AutofacBuilder.cs
+++ b/Rhino.ServiceBus.Autofac/AutofacBuilder.cs
@@ -219,11 +219,11 @@ namespace Rhino.ServiceBus.Autofac
             builder.Update(container);
         }
 
-        public void RegisterRhinoQueuesTransport(string path, bool enablePerformanceCounters)
+        public void RegisterRhinoQueuesTransport(string queuePath, string subscriptionPath, bool enablePerformanceCounters)
         {
             var builder = new ContainerBuilder();
             builder.RegisterType<PhtSubscriptionStorage>()
-                .WithParameter("subscriptionPath", path + "_subscriptions.esent")
+                .WithParameter("subscriptionPath", subscriptionPath)
                 .As<ISubscriptionStorage>()
                 .SingleInstance();
             builder.RegisterType<RhinoQueuesTransport>()
@@ -231,7 +231,7 @@ namespace Rhino.ServiceBus.Autofac
                 .WithParameter("endpoint", config.Endpoint)
                 .WithParameter("queueIsolationLevel", config.IsolationLevel)
                 .WithParameter("numberOfRetries", config.NumberOfRetries)
-                .WithParameter("path", path + ".esent")
+                .WithParameter("path", queuePath)
                 .WithParameter("enablePerformanceCounters", enablePerformanceCounters)
                 .As<ITransport>()
                 .SingleInstance();
@@ -251,7 +251,7 @@ namespace Rhino.ServiceBus.Autofac
                 .SingleInstance();
             builder.RegisterType<RhinoQueuesOneWayBus>()
                 .WithParameter("messageOwners", oneWayConfig.MessageOwners)
-                .WithParameter("path", busConfig.ConstructedPath + ".esent")
+                .WithParameter("path", busConfig.QueuePath)
                 .WithParameter("enablePerformanceCounters", busConfig.EnablePerformanceCounters)
                 .As<IOnewayBus>()
                 .SingleInstance();

--- a/Rhino.ServiceBus.Castle/CastleBuilder.cs
+++ b/Rhino.ServiceBus.Castle/CastleBuilder.cs
@@ -252,7 +252,7 @@ namespace Rhino.ServiceBus.Castle
                        .DependsOn(new { messageOwners = oneWayConfig.MessageOwners }));
         }
 
-        public void RegisterRhinoQueuesTransport(string path, bool enablePerformanceCounters)
+        public void RegisterRhinoQueuesTransport(string queuePath, string subscriptionPath, bool enablePerformanceCounters)
         {
             container.Register(
                 Component.For<ISubscriptionStorage>()
@@ -260,7 +260,7 @@ namespace Rhino.ServiceBus.Castle
                     .ImplementedBy(typeof(PhtSubscriptionStorage))
                     .DependsOn(new
                     {
-                        subscriptionPath = path + "_subscriptions.esent"
+                        subscriptionPath
                     }),
                 Component.For<ITransport>()
                     .LifeStyle.Is(LifestyleType.Singleton)
@@ -271,7 +271,7 @@ namespace Rhino.ServiceBus.Castle
                         endpoint = config.Endpoint,
                         queueIsolationLevel = config.IsolationLevel,
                         numberOfRetries = config.NumberOfRetries,
-                        path = path + ".esent",
+                        path = queuePath,
                         enablePerformanceCounters
                     }),
                 Component.For<IMessageBuilder<MessagePayload>>()
@@ -294,7 +294,7 @@ namespace Rhino.ServiceBus.Castle
                         .DependsOn(new
                         {
                             messageOwners = oneWayConfig.MessageOwners.ToArray(),
-                            path = busConfig.ConstructedPath + ".esent",
+                            path = busConfig.QueuePath,
                             enablePerformanceCounters = busConfig.EnablePerformanceCounters
                         })
                     );

--- a/Rhino.ServiceBus.Castle/CastleBuilder.cs
+++ b/Rhino.ServiceBus.Castle/CastleBuilder.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Messaging;
 using Castle.Core;
@@ -253,7 +252,7 @@ namespace Rhino.ServiceBus.Castle
                        .DependsOn(new { messageOwners = oneWayConfig.MessageOwners }));
         }
 
-        public void RegisterRhinoQueuesTransport(string path, string name, bool enablePerformanceCounters)
+        public void RegisterRhinoQueuesTransport(string path, bool enablePerformanceCounters)
         {
             container.Register(
                 Component.For<ISubscriptionStorage>()
@@ -261,7 +260,7 @@ namespace Rhino.ServiceBus.Castle
                     .ImplementedBy(typeof(PhtSubscriptionStorage))
                     .DependsOn(new
                     {
-                        subscriptionPath = Path.Combine(path, name + "_subscriptions.esent")
+                        subscriptionPath = path + "_subscriptions.esent"
                     }),
                 Component.For<ITransport>()
                     .LifeStyle.Is(LifestyleType.Singleton)
@@ -272,7 +271,7 @@ namespace Rhino.ServiceBus.Castle
                         endpoint = config.Endpoint,
                         queueIsolationLevel = config.IsolationLevel,
                         numberOfRetries = config.NumberOfRetries,
-                        path = Path.Combine(path, name + ".esent"),
+                        path = path + ".esent",
                         enablePerformanceCounters
                     }),
                 Component.For<IMessageBuilder<MessagePayload>>()
@@ -295,7 +294,7 @@ namespace Rhino.ServiceBus.Castle
                         .DependsOn(new
                         {
                             messageOwners = oneWayConfig.MessageOwners.ToArray(),
-                            path = Path.Combine(busConfig.Path,  "one_way.esent"),
+                            path = busConfig.ConstructedPath + ".esent",
                             enablePerformanceCounters = busConfig.EnablePerformanceCounters
                         })
                     );

--- a/Rhino.ServiceBus.Castle/CastleBuilder.cs
+++ b/Rhino.ServiceBus.Castle/CastleBuilder.cs
@@ -252,15 +252,16 @@ namespace Rhino.ServiceBus.Castle
                        .DependsOn(new { messageOwners = oneWayConfig.MessageOwners }));
         }
 
-        public void RegisterRhinoQueuesTransport(string queuePath, string subscriptionPath, bool enablePerformanceCounters)
+        public void RegisterRhinoQueuesTransport()
         {
+            var busConfig = config.ConfigurationSection.Bus;
             container.Register(
                 Component.For<ISubscriptionStorage>()
                     .LifeStyle.Is(LifestyleType.Singleton)
                     .ImplementedBy(typeof(PhtSubscriptionStorage))
                     .DependsOn(new
                     {
-                        subscriptionPath
+                        subscriptionPath = busConfig.SubscriptionPath
                     }),
                 Component.For<ITransport>()
                     .LifeStyle.Is(LifestyleType.Singleton)
@@ -271,8 +272,8 @@ namespace Rhino.ServiceBus.Castle
                         endpoint = config.Endpoint,
                         queueIsolationLevel = config.IsolationLevel,
                         numberOfRetries = config.NumberOfRetries,
-                        path = queuePath,
-                        enablePerformanceCounters
+                        path = busConfig.QueuePath,
+                        enablePerformanceCounters = busConfig.EnablePerformanceCounters
                     }),
                 Component.For<IMessageBuilder<MessagePayload>>()
                     .ImplementedBy<RhinoQueuesMessageBuilder>()

--- a/Rhino.ServiceBus.Spring/SpringBuilder.cs
+++ b/Rhino.ServiceBus.Spring/SpringBuilder.cs
@@ -203,9 +203,9 @@ namespace Rhino.ServiceBus.Spring
             applicationContext.RegisterSingleton<IOnewayBus>(() => new MsmqOnewayBus(oneWayConfig.MessageOwners, applicationContext.Get<IMessageBuilder<Message>>()));
         }
 
-        public void RegisterRhinoQueuesTransport(string path, bool enablePerformanceCounters)
+        public void RegisterRhinoQueuesTransport(string queuePath, string subscriptionPath, bool enablePerformanceCounters)
         {
-            applicationContext.RegisterSingleton<ISubscriptionStorage>(() => new PhtSubscriptionStorage(path + "_subscriptions.esent",
+            applicationContext.RegisterSingleton<ISubscriptionStorage>(() => new PhtSubscriptionStorage(subscriptionPath,
                                                                                   applicationContext.Get<IMessageSerializer>(),
                                                                                   applicationContext.Get<IReflection>()));
 
@@ -213,7 +213,7 @@ namespace Rhino.ServiceBus.Spring
                                                                                                                                     applicationContext.Get<IEndpointRouter>(),
                                                                                                                                     applicationContext.Get<IMessageSerializer>(),
                                                                                                                                     config.ThreadCount,
-                                                                                                                                    path + ".esent",
+                                                                                                                                    queuePath,
                                                                                                                                     config.IsolationLevel,
                                                                                                                                     config.NumberOfRetries,
                                                                                                                                     enablePerformanceCounters,
@@ -228,7 +228,7 @@ namespace Rhino.ServiceBus.Spring
             var busConfig = config.ConfigurationSection.Bus;
 
             applicationContext.RegisterSingleton<IMessageBuilder<MessagePayload>>(() => new RhinoQueuesMessageBuilder(applicationContext.Get<IMessageSerializer>()));
-            applicationContext.RegisterSingleton<IOnewayBus>(() => new RhinoQueuesOneWayBus(oneWayConfig.MessageOwners, applicationContext.Get<IMessageSerializer>(), busConfig.ConstructedPath + ".esent", busConfig.EnablePerformanceCounters, applicationContext.Get<IMessageBuilder<MessagePayload>>()));
+            applicationContext.RegisterSingleton<IOnewayBus>(() => new RhinoQueuesOneWayBus(oneWayConfig.MessageOwners, applicationContext.Get<IMessageSerializer>(), busConfig.QueuePath, busConfig.EnablePerformanceCounters, applicationContext.Get<IMessageBuilder<MessagePayload>>()));
         }
 
         public void RegisterSecurity(byte[] key)

--- a/Rhino.ServiceBus.Spring/SpringBuilder.cs
+++ b/Rhino.ServiceBus.Spring/SpringBuilder.cs
@@ -203,9 +203,10 @@ namespace Rhino.ServiceBus.Spring
             applicationContext.RegisterSingleton<IOnewayBus>(() => new MsmqOnewayBus(oneWayConfig.MessageOwners, applicationContext.Get<IMessageBuilder<Message>>()));
         }
 
-        public void RegisterRhinoQueuesTransport(string queuePath, string subscriptionPath, bool enablePerformanceCounters)
+        public void RegisterRhinoQueuesTransport()
         {
-            applicationContext.RegisterSingleton<ISubscriptionStorage>(() => new PhtSubscriptionStorage(subscriptionPath,
+            var busConfig = config.ConfigurationSection.Bus;
+            applicationContext.RegisterSingleton<ISubscriptionStorage>(() => new PhtSubscriptionStorage(busConfig.SubscriptionPath,
                                                                                   applicationContext.Get<IMessageSerializer>(),
                                                                                   applicationContext.Get<IReflection>()));
 
@@ -213,10 +214,10 @@ namespace Rhino.ServiceBus.Spring
                                                                                                                                     applicationContext.Get<IEndpointRouter>(),
                                                                                                                                     applicationContext.Get<IMessageSerializer>(),
                                                                                                                                     config.ThreadCount,
-                                                                                                                                    queuePath,
+                                                                                                                                    busConfig.QueuePath,
                                                                                                                                     config.IsolationLevel,
                                                                                                                                     config.NumberOfRetries,
-                                                                                                                                    enablePerformanceCounters,
+                                                                                                                                    busConfig.EnablePerformanceCounters,
                                                                                                                                     applicationContext.Get<IMessageBuilder<MessagePayload>>()));
 
             applicationContext.RegisterSingleton<IMessageBuilder<MessagePayload>>(() => new RhinoQueuesMessageBuilder(applicationContext.Get<IMessageSerializer>()));

--- a/Rhino.ServiceBus.Spring/SpringBuilder.cs
+++ b/Rhino.ServiceBus.Spring/SpringBuilder.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Linq;
 using System.Messaging;
 
@@ -204,9 +203,9 @@ namespace Rhino.ServiceBus.Spring
             applicationContext.RegisterSingleton<IOnewayBus>(() => new MsmqOnewayBus(oneWayConfig.MessageOwners, applicationContext.Get<IMessageBuilder<Message>>()));
         }
 
-        public void RegisterRhinoQueuesTransport(string path, string name, bool enablePerformanceCounters)
+        public void RegisterRhinoQueuesTransport(string path, bool enablePerformanceCounters)
         {
-            applicationContext.RegisterSingleton<ISubscriptionStorage>(() => new PhtSubscriptionStorage(Path.Combine(path, name + "_subscriptions.esent"),
+            applicationContext.RegisterSingleton<ISubscriptionStorage>(() => new PhtSubscriptionStorage(path + "_subscriptions.esent",
                                                                                   applicationContext.Get<IMessageSerializer>(),
                                                                                   applicationContext.Get<IReflection>()));
 
@@ -214,7 +213,7 @@ namespace Rhino.ServiceBus.Spring
                                                                                                                                     applicationContext.Get<IEndpointRouter>(),
                                                                                                                                     applicationContext.Get<IMessageSerializer>(),
                                                                                                                                     config.ThreadCount,
-                                                                                                                                    Path.Combine(path, name + ".esent"),
+                                                                                                                                    path + ".esent",
                                                                                                                                     config.IsolationLevel,
                                                                                                                                     config.NumberOfRetries,
                                                                                                                                     enablePerformanceCounters,
@@ -229,7 +228,7 @@ namespace Rhino.ServiceBus.Spring
             var busConfig = config.ConfigurationSection.Bus;
 
             applicationContext.RegisterSingleton<IMessageBuilder<MessagePayload>>(() => new RhinoQueuesMessageBuilder(applicationContext.Get<IMessageSerializer>()));
-            applicationContext.RegisterSingleton<IOnewayBus>(() => new RhinoQueuesOneWayBus(oneWayConfig.MessageOwners, applicationContext.Get<IMessageSerializer>(), busConfig.Path, busConfig.EnablePerformanceCounters, applicationContext.Get<IMessageBuilder<MessagePayload>>()));
+            applicationContext.RegisterSingleton<IOnewayBus>(() => new RhinoQueuesOneWayBus(oneWayConfig.MessageOwners, applicationContext.Get<IMessageSerializer>(), busConfig.ConstructedPath + ".esent", busConfig.EnablePerformanceCounters, applicationContext.Get<IMessageBuilder<MessagePayload>>()));
         }
 
         public void RegisterSecurity(byte[] key)

--- a/Rhino.ServiceBus.StructureMap/StructureMapBuilder.cs
+++ b/Rhino.ServiceBus.StructureMap/StructureMapBuilder.cs
@@ -187,19 +187,20 @@ namespace Rhino.ServiceBus.StructureMap
             });
         }
 
-        public void RegisterRhinoQueuesTransport(string queuePath, string subscriptionPath, bool enablePerformanceCounters)
+        public void RegisterRhinoQueuesTransport()
         {
             container.Configure(c =>
             {
+                var busConfig = config.ConfigurationSection.Bus;
                 c.For<ISubscriptionStorage>().Singleton().Use<PhtSubscriptionStorage>()
-                    .Ctor<string>().Is(subscriptionPath);
+                    .Ctor<string>().Is(busConfig.SubscriptionPath);
                 c.For<ITransport>().Singleton().Use<RhinoQueuesTransport>()
                     .Ctor<int>("threadCount").Is(config.ThreadCount)
                     .Ctor<Uri>().Is(config.Endpoint)
                     .Ctor<IsolationLevel>().Is(config.IsolationLevel)
                     .Ctor<int>("numberOfRetries").Is(config.NumberOfRetries)
-                    .Ctor<string>().Is(queuePath)
-                    .Ctor<bool>().Is(enablePerformanceCounters);
+                    .Ctor<string>().Is(busConfig.QueuePath)
+                    .Ctor<bool>().Is(busConfig.EnablePerformanceCounters);
                 c.For<IMessageBuilder<MessagePayload>>().Singleton().Use<RhinoQueuesMessageBuilder>();
             });
         }

--- a/Rhino.ServiceBus.StructureMap/StructureMapBuilder.cs
+++ b/Rhino.ServiceBus.StructureMap/StructureMapBuilder.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Linq;
 using System.Messaging;
 using System.Transactions;
@@ -188,18 +187,18 @@ namespace Rhino.ServiceBus.StructureMap
             });
         }
 
-        public void RegisterRhinoQueuesTransport(string path, string name, bool enablePerformanceCounters)
+        public void RegisterRhinoQueuesTransport(string path, bool enablePerformanceCounters)
         {
             container.Configure(c =>
             {
                 c.For<ISubscriptionStorage>().Singleton().Use<PhtSubscriptionStorage>()
-                    .Ctor<string>().Is(Path.Combine(path, name + "_subscriptions.esent"));
+                    .Ctor<string>().Is(path + "_subscriptions.esent");
                 c.For<ITransport>().Singleton().Use<RhinoQueuesTransport>()
                     .Ctor<int>("threadCount").Is(config.ThreadCount)
                     .Ctor<Uri>().Is(config.Endpoint)
                     .Ctor<IsolationLevel>().Is(config.IsolationLevel)
                     .Ctor<int>("numberOfRetries").Is(config.NumberOfRetries)
-                    .Ctor<string>().Is(Path.Combine(path, name + ".esent"))
+                    .Ctor<string>().Is(path + ".esent")
                     .Ctor<bool>().Is(enablePerformanceCounters);
                 c.For<IMessageBuilder<MessagePayload>>().Singleton().Use<RhinoQueuesMessageBuilder>();
             });
@@ -215,7 +214,7 @@ namespace Rhino.ServiceBus.StructureMap
                 c.For<IMessageBuilder<MessagePayload>>().Singleton().Use<RhinoQueuesMessageBuilder>();
                 c.For<IOnewayBus>().Singleton().Use<RhinoQueuesOneWayBus>()
                     .Ctor<MessageOwner[]>().Is(oneWayConfig.MessageOwners)
-                    .Ctor<string>().Is(Path.Combine(busConfig.Path, "one_way.esent"))
+                    .Ctor<string>().Is(busConfig.ConstructedPath + ".esent")
                     .Ctor<bool>().Is(busConfig.EnablePerformanceCounters);
             });
         }

--- a/Rhino.ServiceBus.StructureMap/StructureMapBuilder.cs
+++ b/Rhino.ServiceBus.StructureMap/StructureMapBuilder.cs
@@ -187,18 +187,18 @@ namespace Rhino.ServiceBus.StructureMap
             });
         }
 
-        public void RegisterRhinoQueuesTransport(string path, bool enablePerformanceCounters)
+        public void RegisterRhinoQueuesTransport(string queuePath, string subscriptionPath, bool enablePerformanceCounters)
         {
             container.Configure(c =>
             {
                 c.For<ISubscriptionStorage>().Singleton().Use<PhtSubscriptionStorage>()
-                    .Ctor<string>().Is(path + "_subscriptions.esent");
+                    .Ctor<string>().Is(subscriptionPath);
                 c.For<ITransport>().Singleton().Use<RhinoQueuesTransport>()
                     .Ctor<int>("threadCount").Is(config.ThreadCount)
                     .Ctor<Uri>().Is(config.Endpoint)
                     .Ctor<IsolationLevel>().Is(config.IsolationLevel)
                     .Ctor<int>("numberOfRetries").Is(config.NumberOfRetries)
-                    .Ctor<string>().Is(path + ".esent")
+                    .Ctor<string>().Is(queuePath)
                     .Ctor<bool>().Is(enablePerformanceCounters);
                 c.For<IMessageBuilder<MessagePayload>>().Singleton().Use<RhinoQueuesMessageBuilder>();
             });
@@ -214,7 +214,7 @@ namespace Rhino.ServiceBus.StructureMap
                 c.For<IMessageBuilder<MessagePayload>>().Singleton().Use<RhinoQueuesMessageBuilder>();
                 c.For<IOnewayBus>().Singleton().Use<RhinoQueuesOneWayBus>()
                     .Ctor<MessageOwner[]>().Is(oneWayConfig.MessageOwners)
-                    .Ctor<string>().Is(busConfig.ConstructedPath + ".esent")
+                    .Ctor<string>().Is(busConfig.QueuePath)
                     .Ctor<bool>().Is(busConfig.EnablePerformanceCounters);
             });
         }

--- a/Rhino.ServiceBus.Tests/Rhino.ServiceBus.Tests.csproj
+++ b/Rhino.ServiceBus.Tests/Rhino.ServiceBus.Tests.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Containers\StructureMap\ContainerTests.cs" />
     <Compile Include="Containers\Unity\Can_host_in_another_app_domain.cs" />
     <Compile Include="Containers\Unity\ContainerTests.cs" />
+    <Compile Include="RhinoQueues\UsingOneWayBusWithBusNameSpecified.cs" />
     <Compile Include="RhinoQueues\CustomizingMessageConstruction.cs" />
     <Compile Include="CanRouteMessageToConsumerThroughContainer.cs" />
     <Compile Include="CanSendMsgsFromOneWayBus.cs" />

--- a/Rhino.ServiceBus.Tests/RhinoQueues/UsingOneWayBusWithBusNameSpecified.cs
+++ b/Rhino.ServiceBus.Tests/RhinoQueues/UsingOneWayBusWithBusNameSpecified.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.IO;
+using Castle.Windsor;
+using Rhino.ServiceBus.Hosting;
+using Rhino.ServiceBus.Impl;
+using Xunit;
+
+namespace Rhino.ServiceBus.Tests.RhinoQueues
+{
+    public class UsingOneWayBusWithBusNameSpecified : WithDebugging, IDisposable
+    {
+        private const string DEFAULT_STORAGE_DIRECTORY = "one_way.esent";
+        private const string ALTERNATE_BUS_NAME = "another_one_way_bus";
+        private const string ALTERNATE_STORAGE_DIRECTORY = ALTERNATE_BUS_NAME + ".esent";
+
+        private readonly IWindsorContainer container;
+        private readonly string baseStorageLocation;
+        private readonly string defaultOneWayDirectory;
+        private readonly string alternateOneWayDirectory;
+
+        public UsingOneWayBusWithBusNameSpecified()
+        {
+            baseStorageLocation = Directory.GetCurrentDirectory();
+
+            defaultOneWayDirectory = Path.Combine(baseStorageLocation, DEFAULT_STORAGE_DIRECTORY);
+            if (Directory.Exists(defaultOneWayDirectory))
+                Directory.Delete(defaultOneWayDirectory, true);
+
+            alternateOneWayDirectory = Path.Combine(baseStorageLocation, ALTERNATE_STORAGE_DIRECTORY);
+            if (Directory.Exists(alternateOneWayDirectory))
+                Directory.Delete(alternateOneWayDirectory, true);
+
+            var hostConfiguration = new RhinoQueuesHostConfiguration()
+                .Bus(null, ALTERNATE_BUS_NAME)
+                .Receive("System.string", "rhino.queues://nowhere/no_queue");
+
+            container = new WindsorContainer();
+            new OnewayRhinoServiceBusConfiguration()
+                .UseConfiguration(hostConfiguration.ToBusConfiguration())
+                .UseCastleWindsor(container)
+                .Configure();
+            container.Resolve<IOnewayBus>();
+
+        }
+
+        [Fact]
+        public void Storage_should_be_created_base_on_bus_name_location()
+        {
+            Assert.True(Directory.Exists(alternateOneWayDirectory), "Expected directory not found:" + alternateOneWayDirectory);
+        }
+
+        [Fact]
+        public void Storage_should_not_be_created_at_default_location()
+        {
+            Assert.False(Directory.Exists(defaultOneWayDirectory), "Unexpected directory found:" + defaultOneWayDirectory);
+        }
+
+        public void Dispose()
+        {
+            container.Dispose();
+        }
+    }
+}

--- a/Rhino.ServiceBus.Unity/UnityBuilder.cs
+++ b/Rhino.ServiceBus.Unity/UnityBuilder.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Linq;
 using System.Messaging;
 using System.Transactions;
@@ -229,12 +228,12 @@ namespace Rhino.ServiceBus.Unity
                     ));
         }
 
-        public void RegisterRhinoQueuesTransport(string path, string name, bool enablePerformanceCounters)
+        public void RegisterRhinoQueuesTransport(string path, bool enablePerformanceCounters)
         {
             container.RegisterType<ISubscriptionStorage, PhtSubscriptionStorage>(
                 new ContainerControlledLifetimeManager(),
                 new InjectionConstructor(
-                    new InjectionParameter<string>(Path.Combine(path, name + "_subscriptions.esent")),
+                    new InjectionParameter<string>(path + "_subscriptions.esent"),
                     new ResolvedParameter<IMessageSerializer>(),
                     new ResolvedParameter<IReflection>()));
 
@@ -245,7 +244,7 @@ namespace Rhino.ServiceBus.Unity
                     new ResolvedParameter<IEndpointRouter>(),
                     new ResolvedParameter<IMessageSerializer>(),
                     new InjectionParameter<int>(config.ThreadCount),
-                    new InjectionParameter<string>(Path.Combine(path, name + ".esent")),
+                    new InjectionParameter<string>(path + ".esent"),
                     new InjectionParameter<IsolationLevel>(config.IsolationLevel),
                     new InjectionParameter<int>(config.NumberOfRetries),
                     new InjectionParameter<bool>(enablePerformanceCounters),
@@ -267,7 +266,7 @@ namespace Rhino.ServiceBus.Unity
                 new InjectionConstructor(
                     new InjectionParameter<MessageOwner[]>(oneWayConfig.MessageOwners),
                     new ResolvedParameter<IMessageSerializer>(),
-                    new InjectionParameter<string>(Path.Combine(busConfig.Path, "one_way.esent")),
+                    new InjectionParameter<string>(busConfig.ConstructedPath + ".esent"),
                     new InjectionParameter<bool>(busConfig.EnablePerformanceCounters),
                     new ResolvedParameter<IMessageBuilder<MessagePayload>>()));
         }

--- a/Rhino.ServiceBus.Unity/UnityBuilder.cs
+++ b/Rhino.ServiceBus.Unity/UnityBuilder.cs
@@ -228,12 +228,13 @@ namespace Rhino.ServiceBus.Unity
                     ));
         }
 
-        public void RegisterRhinoQueuesTransport(string queuePath, string subscriptionPath, bool enablePerformanceCounters)
+        public void RegisterRhinoQueuesTransport()
         {
+            var busConfig = config.ConfigurationSection.Bus;
             container.RegisterType<ISubscriptionStorage, PhtSubscriptionStorage>(
                 new ContainerControlledLifetimeManager(),
                 new InjectionConstructor(
-                    new InjectionParameter<string>(subscriptionPath),
+                    new InjectionParameter<string>(busConfig.SubscriptionPath),
                     new ResolvedParameter<IMessageSerializer>(),
                     new ResolvedParameter<IReflection>()));
 
@@ -244,10 +245,10 @@ namespace Rhino.ServiceBus.Unity
                     new ResolvedParameter<IEndpointRouter>(),
                     new ResolvedParameter<IMessageSerializer>(),
                     new InjectionParameter<int>(config.ThreadCount),
-                    new InjectionParameter<string>(queuePath),
+                    new InjectionParameter<string>(busConfig.QueuePath),
                     new InjectionParameter<IsolationLevel>(config.IsolationLevel),
                     new InjectionParameter<int>(config.NumberOfRetries),
-                    new InjectionParameter<bool>(enablePerformanceCounters),
+                    new InjectionParameter<bool>(busConfig.EnablePerformanceCounters),
                     new ResolvedParameter<IMessageBuilder<MessagePayload>>()));
 
             container.RegisterType<IMessageBuilder<MessagePayload>, RhinoQueuesMessageBuilder>(

--- a/Rhino.ServiceBus.Unity/UnityBuilder.cs
+++ b/Rhino.ServiceBus.Unity/UnityBuilder.cs
@@ -228,12 +228,12 @@ namespace Rhino.ServiceBus.Unity
                     ));
         }
 
-        public void RegisterRhinoQueuesTransport(string path, bool enablePerformanceCounters)
+        public void RegisterRhinoQueuesTransport(string queuePath, string subscriptionPath, bool enablePerformanceCounters)
         {
             container.RegisterType<ISubscriptionStorage, PhtSubscriptionStorage>(
                 new ContainerControlledLifetimeManager(),
                 new InjectionConstructor(
-                    new InjectionParameter<string>(path + "_subscriptions.esent"),
+                    new InjectionParameter<string>(subscriptionPath),
                     new ResolvedParameter<IMessageSerializer>(),
                     new ResolvedParameter<IReflection>()));
 
@@ -244,7 +244,7 @@ namespace Rhino.ServiceBus.Unity
                     new ResolvedParameter<IEndpointRouter>(),
                     new ResolvedParameter<IMessageSerializer>(),
                     new InjectionParameter<int>(config.ThreadCount),
-                    new InjectionParameter<string>(path + ".esent"),
+                    new InjectionParameter<string>(queuePath),
                     new InjectionParameter<IsolationLevel>(config.IsolationLevel),
                     new InjectionParameter<int>(config.NumberOfRetries),
                     new InjectionParameter<bool>(enablePerformanceCounters),
@@ -266,7 +266,7 @@ namespace Rhino.ServiceBus.Unity
                 new InjectionConstructor(
                     new InjectionParameter<MessageOwner[]>(oneWayConfig.MessageOwners),
                     new ResolvedParameter<IMessageSerializer>(),
-                    new InjectionParameter<string>(busConfig.ConstructedPath + ".esent"),
+                    new InjectionParameter<string>(busConfig.QueuePath),
                     new InjectionParameter<bool>(busConfig.EnablePerformanceCounters),
                     new ResolvedParameter<IMessageBuilder<MessagePayload>>()));
         }

--- a/Rhino.ServiceBus/Config/BusElement.cs
+++ b/Rhino.ServiceBus/Config/BusElement.cs
@@ -68,6 +68,15 @@ namespace Rhino.ServiceBus.Config
             set { this["path"] = value; }
         }
 
+        public string ConstructedPath
+        {
+            get
+            {
+                //Due to validation checks elsewhere, path should never be null except in the cases of a one-way bus
+                return System.IO.Path.Combine(Path, Name == null || Name.Trim().Length == 0 ? "one_way" : Name);
+            }
+        }
+
         public bool EnablePerformanceCounters
         {
             get { return (bool)this["enablePerformanceCounters"]; }

--- a/Rhino.ServiceBus/Config/BusElement.cs
+++ b/Rhino.ServiceBus/Config/BusElement.cs
@@ -64,17 +64,31 @@ namespace Rhino.ServiceBus.Config
 
         public string Path
         {
-            get { return (this["path"] as string) ?? System.IO.Path.GetFullPath(AppDomain.CurrentDomain.BaseDirectory); }
+            get { return this["path"] as string; }
             set { this["path"] = value; }
         }
-
-        public string ConstructedPath
+        
+        private string BasePath
         {
             get
             {
+                var basePath = Path ?? System.IO.Path.GetFullPath(AppDomain.CurrentDomain.BaseDirectory);
+                
                 //Due to validation checks elsewhere, path should never be null except in the cases of a one-way bus
-                return System.IO.Path.Combine(Path, Name == null || Name.Trim().Length == 0 ? "one_way" : Name);
+                var folderName = Name == null || Name.Trim().Length == 0 ? "one_way" : Name;
+
+                return System.IO.Path.Combine(basePath, folderName);
             }
+        }
+
+        public string QueuePath
+        {
+            get { return BasePath + ".esent"; }
+        }
+
+        public string SubscriptionPath
+        {
+            get { return BasePath + "_subscriptions.esent"; }
         }
 
         public bool EnablePerformanceCounters

--- a/Rhino.ServiceBus/Config/IBusContainerBuilder.cs
+++ b/Rhino.ServiceBus/Config/IBusContainerBuilder.cs
@@ -15,7 +15,7 @@ namespace Rhino.ServiceBus.Config
         void RegisterMsmqTransport(Type queueStrategyType);
         void RegisterQueueCreation();
         void RegisterMsmqOneWay();
-        void RegisterRhinoQueuesTransport(string path, bool enablePerformanceCounters);
+        void RegisterRhinoQueuesTransport(string queuePath, string subscriptionPath, bool enablePerformanceCounters);
         void RegisterRhinoQueuesOneWay();
         void RegisterSecurity(byte[] key);
         void RegisterNoSecurity();

--- a/Rhino.ServiceBus/Config/IBusContainerBuilder.cs
+++ b/Rhino.ServiceBus/Config/IBusContainerBuilder.cs
@@ -15,7 +15,7 @@ namespace Rhino.ServiceBus.Config
         void RegisterMsmqTransport(Type queueStrategyType);
         void RegisterQueueCreation();
         void RegisterMsmqOneWay();
-        void RegisterRhinoQueuesTransport(string path, string name, bool enablePerformanceCounters);
+        void RegisterRhinoQueuesTransport(string path, bool enablePerformanceCounters);
         void RegisterRhinoQueuesOneWay();
         void RegisterSecurity(byte[] key);
         void RegisterNoSecurity();

--- a/Rhino.ServiceBus/Config/IBusContainerBuilder.cs
+++ b/Rhino.ServiceBus/Config/IBusContainerBuilder.cs
@@ -15,7 +15,7 @@ namespace Rhino.ServiceBus.Config
         void RegisterMsmqTransport(Type queueStrategyType);
         void RegisterQueueCreation();
         void RegisterMsmqOneWay();
-        void RegisterRhinoQueuesTransport(string queuePath, string subscriptionPath, bool enablePerformanceCounters);
+        void RegisterRhinoQueuesTransport();
         void RegisterRhinoQueuesOneWay();
         void RegisterSecurity(byte[] key);
         void RegisterNoSecurity();

--- a/Rhino.ServiceBus/Config/RhinoQueuesConfigurationAware.cs
+++ b/Rhino.ServiceBus/Config/RhinoQueuesConfigurationAware.cs
@@ -22,7 +22,7 @@ namespace Rhino.ServiceBus.Config
                 throw new ConfigurationErrorsException(
                     "Could not find attribute 'name' in node 'bus' in configuration");
 
-            builder.RegisterRhinoQueuesTransport(busConfigSection.Path, busConfigSection.Name, busConfigSection.EnablePerformanceCounters);
+            builder.RegisterRhinoQueuesTransport(busConfigSection.ConstructedPath, busConfigSection.EnablePerformanceCounters);
         }
     }
 }

--- a/Rhino.ServiceBus/Config/RhinoQueuesConfigurationAware.cs
+++ b/Rhino.ServiceBus/Config/RhinoQueuesConfigurationAware.cs
@@ -22,7 +22,7 @@ namespace Rhino.ServiceBus.Config
                 throw new ConfigurationErrorsException(
                     "Could not find attribute 'name' in node 'bus' in configuration");
 
-            builder.RegisterRhinoQueuesTransport(busConfigSection.ConstructedPath, busConfigSection.EnablePerformanceCounters);
+            builder.RegisterRhinoQueuesTransport(busConfigSection.QueuePath, busConfigSection.SubscriptionPath, busConfigSection.EnablePerformanceCounters);
         }
     }
 }

--- a/Rhino.ServiceBus/Config/RhinoQueuesConfigurationAware.cs
+++ b/Rhino.ServiceBus/Config/RhinoQueuesConfigurationAware.cs
@@ -22,7 +22,7 @@ namespace Rhino.ServiceBus.Config
                 throw new ConfigurationErrorsException(
                     "Could not find attribute 'name' in node 'bus' in configuration");
 
-            builder.RegisterRhinoQueuesTransport(busConfigSection.QueuePath, busConfigSection.SubscriptionPath, busConfigSection.EnablePerformanceCounters);
+            builder.RegisterRhinoQueuesTransport();
         }
     }
 }

--- a/Rhino.ServiceBus/RhinoQueues/RhinoQueuesTransport.cs
+++ b/Rhino.ServiceBus/RhinoQueues/RhinoQueuesTransport.cs
@@ -149,7 +149,7 @@ namespace Rhino.ServiceBus.RhinoQueues
 
             if (port == ANY_AVAILABLE_PORT)
             {
-                ConfigureAndStartPortManagerOnAnyAvailablePort();
+                ConfigureAndStartQueueManagerOnAnyAvailablePort();
                 port = queueManager.Endpoint.Port;
                 endpoint = new Uri(endpoint.OriginalString.Replace(endpoint.Host + ":" + ANY_AVAILABLE_PORT, endpoint.Host + ":" + port));
             }
@@ -176,7 +176,7 @@ namespace Rhino.ServiceBus.RhinoQueues
                 started();
         }
 
-        private void ConfigureAndStartPortManagerOnAnyAvailablePort()
+        private void ConfigureAndStartQueueManagerOnAnyAvailablePort()
         {
             int port;
             while (true)


### PR DESCRIPTION
Corey,

This pull contains one functional change.  In the event that a one-way bus does not have a storage path specified in the configuration but does specify a bus name, the bus name is now used in-lieu of "one_way" in generating the default storage path.

CAUTION: This could be a breaking change in the even that someone out there besides me is specifying queue names for their one way buses.  This will change the storage location of said buses causing any existing messages in said queues to "disappear."

In addition I fixed a method naming error I made in my last pull request and finally went whole-hog in drying out the path generation code that was scattered across the IBusContainerBuilder implementations.

My _Standard Disclaimer_ about failing tests on my local machine still applies.

--Ken
