### PR TITLE
Added convenience methods SendToSelf and DelaySendToSelf to IServiceBus

### DIFF
--- a/Rhino.ServiceBus/IServiceBus.cs
+++ b/Rhino.ServiceBus/IServiceBus.cs
@@ -49,11 +49,6 @@ namespace Rhino.ServiceBus
         /// </summary>
         void Send(params object[] messages);
 
-        /// <summary>
-        /// Send the message to this bus endpoint
-        /// </summary>
-        void SendToSelf(params object[] messages);
-
 		/// <summary>
 		/// Invoke consumers for the relevant messages managed by the current
 		/// service bus instance. This happens immediately and on the current thread.
@@ -100,11 +95,6 @@ namespace Rhino.ServiceBus
         void Unsubscribe(Type type);
 
 		/// <summary>
-		/// Handles the current message later.
-		/// </summary>
-    	void HandleCurrentMessageLater();
-
-		/// <summary>
 		/// Send the message with a built in delay in its processing
 		/// </summary>
 		/// <param name="endpoint">The endpoint.</param>
@@ -118,12 +108,5 @@ namespace Rhino.ServiceBus
         /// <param name="time">The time.</param>
         /// <param name="msgs">The messages.</param>
         void DelaySend(DateTime time, params object[] msgs);
-
-        /// <summary>
-        /// Send the message with a built in delay in its processing to this bus endpoint
-        /// </summary>
-        /// <param name="time">The time.</param>
-        /// <param name="msgs">The messages.</param>
-        void DelaySendToSelf(DateTime time, params object[] msgs);
     }
 }

--- a/Rhino.ServiceBus/IServiceBus.cs
+++ b/Rhino.ServiceBus/IServiceBus.cs
@@ -49,6 +49,11 @@ namespace Rhino.ServiceBus
         /// </summary>
         void Send(params object[] messages);
 
+        /// <summary>
+        /// Send the message to this bus endpoint
+        /// </summary>
+        void SendToSelf(params object[] messages);
+
 		/// <summary>
 		/// Invoke consumers for the relevant messages managed by the current
 		/// service bus instance. This happens immediately and on the current thread.
@@ -113,5 +118,12 @@ namespace Rhino.ServiceBus
         /// <param name="time">The time.</param>
         /// <param name="msgs">The messages.</param>
         void DelaySend(DateTime time, params object[] msgs);
+
+        /// <summary>
+        /// Send the message with a built in delay in its processing to this bus endpoint
+        /// </summary>
+        /// <param name="time">The time.</param>
+        /// <param name="msgs">The messages.</param>
+        void DelaySendToSelf(DateTime time, params object[] msgs);
     }
 }

--- a/Rhino.ServiceBus/Impl/DefaultServiceBus.cs
+++ b/Rhino.ServiceBus/Impl/DefaultServiceBus.cs
@@ -92,11 +92,6 @@ namespace Rhino.ServiceBus.Impl
             Send(messageOwners.GetEndpointForMessageBatch(messages), messages);
         }
 
-        public void SendToSelf(params object[] messages)
-        {
-            Send(Endpoint, messages);
-        }
-
 		public void ConsumeMessages(params object[] messages)
 		{
 			foreach (var message in messages)
@@ -301,14 +296,6 @@ namespace Rhino.ServiceBus.Impl
         }
 
         /// <summary>
-    	/// Handles the current message later.
-    	/// </summary>
-    	public void HandleCurrentMessageLater()
-    	{
-            transport.Send(Endpoint, DateTime.Now, new[] { currentMessage });
-    	}
-
-        /// <summary>
     	/// Send the message with a built in delay in its processing
     	/// </summary>
     	/// <param name="endpoint">The endpoint.</param>
@@ -329,16 +316,6 @@ namespace Rhino.ServiceBus.Impl
             DelaySend(messageOwners.GetEndpointForMessageBatch(msgs), time, msgs);
         }
 
-        /// <summary>
-        /// Send the message with a built in delay in its processing to this bus endpoint
-        /// </summary>
-        /// <param name="time">The time.</param>
-        /// <param name="msgs">The messages.</param>
-        public void DelaySendToSelf(DateTime time, params object[] msgs)
-        {
-            DelaySend(Endpoint, time, msgs);
-        }
-        
         private void AutomaticallySubscribeConsumerMessages()
         {
             var handlers = serviceLocator.GetAllHandlersFor(typeof(IMessageConsumer));

--- a/Rhino.ServiceBus/Impl/DefaultServiceBus.cs
+++ b/Rhino.ServiceBus/Impl/DefaultServiceBus.cs
@@ -92,6 +92,11 @@ namespace Rhino.ServiceBus.Impl
             Send(messageOwners.GetEndpointForMessageBatch(messages), messages);
         }
 
+        public void SendToSelf(params object[] messages)
+        {
+            Send(Endpoint, messages);
+        }
+
 		public void ConsumeMessages(params object[] messages)
 		{
 			foreach (var message in messages)
@@ -322,6 +327,16 @@ namespace Rhino.ServiceBus.Impl
         public void DelaySend(DateTime time, params object[] msgs)
         {
             DelaySend(messageOwners.GetEndpointForMessageBatch(msgs), time, msgs);
+        }
+
+        /// <summary>
+        /// Send the message with a built in delay in its processing to this bus endpoint
+        /// </summary>
+        /// <param name="time">The time.</param>
+        /// <param name="msgs">The messages.</param>
+        public void DelaySendToSelf(DateTime time, params object[] msgs)
+        {
+            DelaySend(Endpoint, time, msgs);
         }
         
         private void AutomaticallySubscribeConsumerMessages()

--- a/Rhino.ServiceBus/Rhino.ServiceBus.csproj
+++ b/Rhino.ServiceBus/Rhino.ServiceBus.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Msmq\QueueCreationModule.cs" />
     <Compile Include="RhinoQueues\RhinoQueuesMessageBuilder.cs" />
     <Compile Include="RhinoQueues\RhinoQueuesOneWayBus.cs" />
+    <Compile Include="ServiceBusExtensions.cs" />
     <Compile Include="Transport\SubQueue.cs" />
     <Compile Include="Msmq\TransportActions\ShutDownAction.cs" />
     <Compile Include="Msmq\TransportState.cs" />

--- a/Rhino.ServiceBus/ServiceBusExtensions.cs
+++ b/Rhino.ServiceBus/ServiceBusExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace Rhino.ServiceBus
+{
+    /// <summary>
+    /// Provides some convenience extension methods to IServiceBus
+    /// </summary>
+    public static class ServiceBusExtensions
+    {
+        /// <summary>
+        /// Handles the current message later.
+        /// </summary>
+        public static void HandleCurrentMessageLater(this IServiceBus serviceBus)
+        {
+            serviceBus.DelaySend(serviceBus.Endpoint, DateTime.Now, serviceBus.CurrentMessageInformation.Message);
+        }
+
+        /// <summary>
+        /// Sends the message directly to this bus endpoint
+        /// </summary>
+        public static void SendToSelf(this IServiceBus serviceBus, params object[] messages)
+        {
+            serviceBus.Send(serviceBus.Endpoint, messages);
+        }
+
+        /// <summary>
+        /// Send the message with a built in delay in its processing to this bus endpoint
+        /// </summary>
+        public static void DelaySendToSelf(this IServiceBus serviceBus, DateTime time, params object[] msgs)
+        {
+            serviceBus.DelaySend(serviceBus.Endpoint, time, msgs);
+        }
+    }
+}


### PR DESCRIPTION
Added convenience methods SendToSelf and DelaySendToSelf to IServiceBus

I sometimes want to send message back to the same bus (let say a "ping" message), so I thought that it would be nice to have in RSB such methods instead of calling this.bus.DelaySend(time, this.bus.Endpoint, message)
