### PR TITLE
Move storage path setting from RhinoQueuesHostConfiguration to HostConfiguration

### DIFF
--- a/Rhino.ServiceBus/Hosting/HostConfiguration.cs
+++ b/Rhino.ServiceBus/Hosting/HostConfiguration.cs
@@ -13,6 +13,7 @@ namespace Rhino.ServiceBus.Hosting
         private string LoadBalancerEndpoint { get; set; }
         private string SecurityKey { get; set; }
         protected string LogEndpoint { get; set; }
+        private string Path { get; set; }
         private IDictionary<string, HostConfigMessageEndpoint> Messages { get; set; }
 
         public HostConfiguration()
@@ -70,6 +71,12 @@ namespace Rhino.ServiceBus.Hosting
             return this;
         }
 
+        public HostConfiguration StoragePath(string path)
+        {
+            Path = path;
+            return this;
+        }
+
         public HostConfiguration Receive(string messageName, string endpoint)
         {
             return Receive(messageName, endpoint, false);
@@ -95,6 +102,7 @@ namespace Rhino.ServiceBus.Hosting
             config.Bus.LoadBalancerEndpoint = LoadBalancerEndpoint;
             config.Bus.LogEndpoint = LogEndpoint;
             config.Bus.Transactional = Transactional.ToString();
+            config.Bus.Path = Path;
             config.Security.Key = SecurityKey;
             foreach (var message in Messages)
             {

--- a/Rhino.ServiceBus/Hosting/RhinoQueuesHostConfiguration.cs
+++ b/Rhino.ServiceBus/Hosting/RhinoQueuesHostConfiguration.cs
@@ -4,18 +4,11 @@ namespace Rhino.ServiceBus.Hosting
 {
     public class RhinoQueuesHostConfiguration : HostConfiguration
     {
-        private string path;
         private bool enablePerformanceCounters;
 
         public RhinoQueuesHostConfiguration()
         {
             enablePerformanceCounters = false;
-        }
-
-        public RhinoQueuesHostConfiguration StoragePath(string path)
-        {
-            this.path = path;
-            return this;
         }
 
         public RhinoQueuesHostConfiguration EnablePerformanceCounters()
@@ -27,9 +20,6 @@ namespace Rhino.ServiceBus.Hosting
         public override BusConfigurationSection ToBusConfiguration()
         {
             var config = base.ToBusConfiguration();
-
-            if (string.IsNullOrEmpty(path) == false)
-                config.Bus.Path = path;
 
             config.Bus.EnablePerformanceCounters = enablePerformanceCounters;
 


### PR DESCRIPTION
By moving this setting from derived configuration class to base class it's actually possible to change the storage path like this:

serviceBusHost.BusConfiguration(c => 
 c.Bus("rhino.queues://localhost/customer", "myqueue")
   .StoragePath(@"c:\my-queue-path")
);

I'm not sure what's the purpose of performance counters that are left there as they are not even used?
