### PR TITLE
Minor serialization/deserialization fixes

### DIFF
--- a/Rhino.ServiceBus.Tests/DefaultReflectionTests.cs
+++ b/Rhino.ServiceBus.Tests/DefaultReflectionTests.cs
@@ -112,6 +112,13 @@ namespace Rhino.ServiceBus.Tests
             Assert.Contains(typeof(ConsumerOf<object>), consumers);
         }
 
+        [Fact]
+        public void Can_CreateInstance_when_type_has_private_constructor()
+        {
+            object objectFromClassWithPrivateConstructor = reflection.CreateInstance(typeof(ClassWithPrivateConstructor), new object[] { });
+            Assert.NotNull(objectFromClassWithPrivateConstructor);
+        }
+
         public class SomeMsg { }
         public class SomeMsgConsumer : GenericConsumer<SomeMsg> { }
         public class GenericConsumer<T> : ConsumerOf<T>
@@ -179,6 +186,12 @@ namespace Rhino.ServiceBus.Tests
                 throw new System.NotImplementedException();
             }
         }
+
+        public class ClassWithPrivateConstructor
+        {
+            private ClassWithPrivateConstructor() { }
+        }
+
     }
     public class TestDictionary<T, TK> : Dictionary<T, TK>
     {

--- a/Rhino.ServiceBus.Tests/XmlSerializerTest.cs
+++ b/Rhino.ServiceBus.Tests/XmlSerializerTest.cs
@@ -50,6 +50,30 @@ namespace Rhino.ServiceBus.Tests
             Assert.Equal(ticks, actual);
         }
 
+        [Fact]
+        public void Can_serialize_and_deserialize_double()
+        {
+            double aDouble = 1.12;
+            var serializer = new XmlMessageSerializer(new DefaultReflection(), new CastleServiceLocator(new WindsorContainer()));
+            var stream = new MemoryStream();
+            serializer.Serialize(new object[] { aDouble }, stream);
+            stream.Position = 0;
+            var actual = (double)serializer.Deserialize(stream)[0];
+            Assert.Equal(aDouble, actual);
+        }
+
+        [Fact]
+        public void Can_serialize_and_deserialize_float()
+        {
+            float aFloat = 1.12f;
+            var serializer = new XmlMessageSerializer(new DefaultReflection(), new CastleServiceLocator(new WindsorContainer()));
+            var stream = new MemoryStream();
+            serializer.Serialize(new object[] { aFloat }, stream);
+            stream.Position = 0;
+            var actual = (float)serializer.Deserialize(stream)[0];
+            Assert.Equal(aFloat, actual);
+        }
+
 		[Fact]
 		public void Can_serialize_and_deserialize_byte_array()
 		{

--- a/Rhino.ServiceBus/Impl/DefaultReflection.cs
+++ b/Rhino.ServiceBus/Impl/DefaultReflection.cs
@@ -56,7 +56,7 @@ namespace Rhino.ServiceBus.Impl
         {
             try
             {
-                return Activator.CreateInstance(type, args);
+                return Activator.CreateInstance(type, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance, null, args, null);
             }
             catch (Exception e)
             {

--- a/Rhino.ServiceBus/Serializers/XmlMessageSerializer.cs
+++ b/Rhino.ServiceBus/Serializers/XmlMessageSerializer.cs
@@ -271,7 +271,13 @@ namespace Rhino.ServiceBus.Serializers
 
             if (value is decimal)
                 return ((decimal) value).ToString(CultureInfo.InvariantCulture);
-            
+
+            if (value is double)
+                return ((double)value).ToString(CultureInfo.InvariantCulture);
+
+            if (value is float)
+                return ((float)value).ToString(CultureInfo.InvariantCulture);
+
             return value.ToString();
         }
 


### PR DESCRIPTION
Added possibility to deserialize types with non-public constructors.

Fixed culture specific serialization issue of float and double. Delimiter was removed when deserializing these types. For example: 10.12 ended up as 1012
