### PR TITLE
Added ability to set custom account when installing windows service

### DIFF
--- a/Rhino.ServiceBus.Host/Actions/InstallAction.cs
+++ b/Rhino.ServiceBus.Host/Actions/InstallAction.cs
@@ -15,7 +15,17 @@ namespace Rhino.ServiceBus.Host.Actions
                 Description = options.Name,
                 Context = new InstallContext()
             };
-			
+
+            if (!string.IsNullOrEmpty(options.Account))
+            {
+                if (string.IsNullOrEmpty(options.Password))
+                {
+                    throw new InvalidOperationException("When /Action is Install and /Account is set /Password is required.");
+                }
+
+                installer.SetUserAccount(options.Account, options.Password);
+            }
+
 			installer.Context.Parameters.Add("assemblypath", GetType().Assembly.Location);
 			
 			installer.Install(new Hashtable());

--- a/Rhino.ServiceBus.Host/ExecutingOptions.cs
+++ b/Rhino.ServiceBus.Host/ExecutingOptions.cs
@@ -14,6 +14,7 @@ namespace Rhino.ServiceBus.Host
         [Argument(ArgumentType.Required, HelpText = "Service name", ShortName = "name")] public string Name;
 
         [Argument(ArgumentType.AtMostOnce, LongName = "Account")] public string Account;
+        [Argument(ArgumentType.AtMostOnce, HelpText="Password for account used when installing service")]public string Password;
 
         [Argument(ArgumentType.AtMostOnce, LongName = "Host")] public string Host;
         [Argument(ArgumentType.AtMostOnce, LongName = "BootStrapper")] public string BootStrapper;
@@ -25,12 +26,6 @@ namespace Rhino.ServiceBus.Host
                 .Append(" /Name:\"")
                 .Append(Name)
 				.Append("\"");
-
-            if(string.IsNullOrEmpty(Account)==false)
-            {
-                sb.Append(" /Account:")
-                .Append(Account);
-            }
 
             if (string.IsNullOrEmpty(Host)==false)
             {

--- a/Rhino.ServiceBus.Host/ProjectInstaller.cs
+++ b/Rhino.ServiceBus.Host/ProjectInstaller.cs
@@ -20,13 +20,12 @@ namespace Rhino.ServiceBus.Host
 			}
 		}
 
-	    public ServiceAccount Account
-	    {
-	        get
-	        {
-	            return serviceProcessInstaller1.Account;
-	        }
-	    }
+		public void SetUserAccount(string username, string password)
+		{
+			serviceProcessInstaller1.Account = ServiceAccount.User;
+			serviceProcessInstaller1.Username = username;
+			serviceProcessInstaller1.Password = password;
+		}
 
 		public ProjectInstaller()
 		{


### PR DESCRIPTION
Hi,

This patch adds ability to set custom account while installing RSB windows service from Rhino.ServiceBus.Host.exe /Action:Install.

I needed to set RSB windows service to run under different account than default Network Service, and to make it work such account needs to have 'Log on as a service' right. .NET windows service installer, which RSB use, sets this right automatically and it is quite hard to set it in different ways, e.x. from command line. Only missing part was to have ability to set custom account as RSB.Host.exe command line argument.
