### PR TITLE
Fixed bug in CastleBootStrapper

### DIFF
--- a/Rhino.ServiceBus.Castle/CastleBootStrapper.cs
+++ b/Rhino.ServiceBus.Castle/CastleBootStrapper.cs
@@ -97,7 +97,7 @@ namespace Rhino.ServiceBus.Castle
 
     	protected virtual void ConfigureConsumer(ComponentRegistration registration)
     	{
-    		registration.Named(registration.Implementation.Name);
+    		registration.Named(registration.Implementation.FullName);
     	}
     }
 }


### PR DESCRIPTION
Fixed bug in CastleBootStrapper that caused problems when there was more than one consumer with the same class name.

It used Type.Name as key, so when there was more than one consumer with the same name, last consumer override previous ones.
