### PR TITLE
Autofac nuspec file versioning fix

### DIFF
--- a/Rhino.ServiceBus.Castle/CastleBootStrapper.cs
+++ b/Rhino.ServiceBus.Castle/CastleBootStrapper.cs
@@ -97,7 +97,7 @@ namespace Rhino.ServiceBus.Castle
 
     	protected virtual void ConfigureConsumer(ComponentRegistration registration)
     	{
-    		registration.Named(registration.Implementation.Name);
+    		registration.Named(registration.Implementation.FullName);
     	}
     }
 }


### PR DESCRIPTION
Looks like there is an explicit version requirement with the Autofac integration in terms of how it is built that is causing problems with the NuGet package for Rhino.ServiceBus.Autofac - the explicit version is called out in the nuspec file as 2.4.4.705, but since it is not surrounded by brackets NuGet interprets that as "greater than or equal to" by default. When we tried starting up a new project (glad to be back working with RSB again :) we ran into this issue as it pulled down the Autofac version 2.4.5.724 instead of the 2.4.4 version and wouldn't run. I was able to fix it by manually running nuget powershell commands but thought I'd submit a quick patch to prevent the issue for others.

Also - not a huge deal, but any thoughts around upgrading to the latest Autofac version? 2.5.2.830 is the current version - might be good to keep up to date there - just wondered what the plan was there.

Thanks,
Matt
