### PR TITLE
Fixed Autofac issue where queue was not created on bus start.

### DIFF
--- a/Rhino.ServiceBus.Autofac/AutofacBuilder.cs
+++ b/Rhino.ServiceBus.Autofac/AutofacBuilder.cs
@@ -200,7 +200,7 @@ namespace Rhino.ServiceBus.Autofac
         {
             var builder = new ContainerBuilder();
             builder.RegisterType<QueueCreationModule>()
-                .AsSelf()
+                .As<IServiceBusAware>()
                 .SingleInstance();
             builder.Update(container);
         }

--- a/Rhino.ServiceBus.Tests/Containers/Autofac/QueueCreationTests.cs
+++ b/Rhino.ServiceBus.Tests/Containers/Autofac/QueueCreationTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Rhino.ServiceBus.Autofac;
+using Rhino.ServiceBus.Hosting;
+using Rhino.ServiceBus.Msmq;
+using Xunit;
+
+namespace Rhino.ServiceBus.Tests.Containers.Autofac
+{
+    public class QueueCreationTests : IDisposable
+    {
+        private const string EndpointUri = "msmq://localhost/autofac-create.test";
+        private readonly Endpoint _endpoint = new Endpoint {Uri = new Uri( EndpointUri )};
+
+        [Fact]
+        public void Endpoint_queue_is_created_on_start()
+        {
+            var host = new DefaultHost();
+            host.BusConfiguration( config => config.Bus( EndpointUri ) );
+
+            host.Start<AutofacTestBootStrapper>();
+            host.Dispose();
+
+            var endpointQueue = MsmqUtil.GetQueuePath( _endpoint );
+            Assert.True( endpointQueue.Exists );
+        }
+
+        public void Dispose()
+        {
+            var endpointQueue = MsmqUtil.GetQueuePath( _endpoint );
+            if ( endpointQueue.Exists )
+            {
+                endpointQueue.Delete();
+            }
+        }
+    }
+
+    public class AutofacTestBootStrapper : AutofacBootStrapper
+    {
+    }
+}

--- a/Rhino.ServiceBus.Tests/Rhino.ServiceBus.Tests.csproj
+++ b/Rhino.ServiceBus.Tests/Rhino.ServiceBus.Tests.csproj
@@ -136,6 +136,7 @@
     <Compile Include="CanCustomizeHeadersWithMsmq.cs" />
     <Compile Include="Containers\Autofac\Can_host_in_another_app_domain.cs" />
     <Compile Include="Containers\Autofac\ContainerTests.cs" />
+    <Compile Include="Containers\Autofac\QueueCreationTests.cs" />
     <Compile Include="Containers\Spring\Can_host_in_another_app_domain.cs" />
     <Compile Include="Containers\Spring\ContainerTests.cs" />
     <Compile Include="Containers\StructureMap\Can_host_in_another_app_domain.cs" />


### PR DESCRIPTION
Issue:
When an Autofac configured DefaultHost was started, the endpoint queue was not created and an exception was thrown when trying to create the subscription subqueue.

Fix:
The QueueCreationModule was not running because of how it was registered in the AutofacBuilder. Changed builder to register module as IServiceBusAware.
