### PR TITLE
Cleanup of message consumers under Castle Windsor

### DIFF
--- a/Rhino.ServiceBus.Castle/CastleServiceLocator.cs
+++ b/Rhino.ServiceBus.Castle/CastleServiceLocator.cs
@@ -40,7 +40,7 @@ namespace Rhino.ServiceBus.Castle
         public IEnumerable<IHandler> GetAllHandlersFor(Type type)
         {
             return (from h in container.Kernel.GetAssignableHandlers(type)
-                   select (IHandler)new DefaultHandler(null, h.ComponentModel.Implementation, () => h.Resolve(CreationContext.CreateEmpty())));
+                   select (IHandler)new DefaultHandler(null, h.ComponentModel.Implementation, () => h.Resolve(new CreationContext(h, container.Kernel.ReleasePolicy, type, null, null, null))));
         }
 
         public void Release(object item)

--- a/Rhino.ServiceBus.Tests/Containers/Castle/ContainerTests.cs
+++ b/Rhino.ServiceBus.Tests/Containers/Castle/ContainerTests.cs
@@ -1,0 +1,157 @@
+using System;
+using Castle.MicroKernel.Registration;
+using Castle.Windsor;
+using Rhino.ServiceBus.Impl;
+using Xunit;
+
+namespace Rhino.ServiceBus.Tests.Containers.Castle
+{
+    public class ContainerTests
+    {
+        private IWindsorContainer container;
+        private IServiceBus bus;
+
+        public ContainerTests()
+        {
+            this.container = new WindsorContainer();
+
+            new RhinoServiceBusConfiguration()
+                .UseCastleWindsor(container)
+                .Configure();
+
+            this.bus = container.Resolve<IServiceBus>();
+        }
+
+        [Fact]
+        public void Disposable_Consumer_is_disposed()
+        {
+            this.container.Register(Component.For<DisposableConsumer>().LifeStyle.Transient);
+
+            DisposableConsumer.ResetCounters();
+            Assert.Equal(0, DisposableConsumer.ConsumedMessages);
+            Assert.Equal(0, DisposableConsumer.NotDisposedInstances);
+
+            bus.ConsumeMessages("TestMessage");
+
+            Assert.Equal(1, DisposableConsumer.ConsumedMessages);
+            Assert.Equal(0, DisposableConsumer.NotDisposedInstances);
+        }
+
+        [Fact]
+        public void Disposable_dependency_of_a_simple_Consumer_is_disposed()
+        {
+            this.container.Register(Component.For<DisposableDependency>().LifeStyle.Transient);
+            this.container.Register(Component.For<ConsumerWithDisposableDependency>().LifeStyle.Transient);
+
+            ConsumerWithDisposableDependency.ResetCounter();
+            DisposableDependency.ResetCounter();
+            Assert.Equal(0, ConsumerWithDisposableDependency.ConsumedMessages);
+            Assert.Equal(0, DisposableDependency.NotDisposedInstances);
+
+            this.bus.ConsumeMessages("TestMessage");
+
+            Assert.Equal(1, ConsumerWithDisposableDependency.ConsumedMessages);
+            Assert.Equal(0, DisposableDependency.NotDisposedInstances);
+        }
+    }
+
+    public class DisposableConsumer : ConsumerOf<string>, IDisposable
+    {
+        public static long NotDisposedInstances = 0;
+        public static long ConsumedMessages = 0;
+
+        private bool disposed;
+
+        public DisposableConsumer()
+        {
+            NotDisposedInstances += 1;
+        }
+
+        public void Consume(string message)
+        {
+            if (this.disposed)
+            {
+                throw new ObjectDisposedException(this.GetType().Name);
+            }
+
+            Assert.True(1 <= NotDisposedInstances);
+
+            ConsumedMessages += 1;
+        }
+
+        public void Dispose()
+        {
+            if (this.disposed == false)
+            {
+                NotDisposedInstances -= 1;
+                this.disposed = true;
+            }
+        }
+
+        public static void ResetCounters()
+        {
+            NotDisposedInstances = 0;
+            ConsumedMessages = 0;
+        }
+    }
+
+    public class DisposableDependency : IDisposable
+    {
+        public static long NotDisposedInstances = 0;
+
+        private bool disposed;
+
+        public DisposableDependency()
+        {
+            NotDisposedInstances += 1;
+        }
+
+        public void Use()
+        {
+            if (this.disposed)
+            {
+                throw new ObjectDisposedException(this.GetType().Name);
+            }
+
+            Assert.True(1 <= NotDisposedInstances);
+        }
+
+        public void Dispose()
+        {
+            if (this.disposed == false)
+            {
+                NotDisposedInstances -= 1;
+                this.disposed = true;
+            }
+        }
+
+        public static void ResetCounter()
+        {
+            NotDisposedInstances = 0;
+        }
+    }
+
+    public class ConsumerWithDisposableDependency : ConsumerOf<string>
+    {
+        public static long ConsumedMessages = 0;
+
+        private DisposableDependency disposableDependency;
+
+        public ConsumerWithDisposableDependency(DisposableDependency disposableDependency)
+        {
+            this.disposableDependency = disposableDependency;
+
+            ConsumedMessages += 1;
+        }
+
+        public void Consume(string message)
+        {
+            this.disposableDependency.Use();
+        }
+
+        public static void ResetCounter()
+        {
+            ConsumedMessages = 0;
+        }
+    }
+}

--- a/Rhino.ServiceBus.Tests/Rhino.ServiceBus.Tests.csproj
+++ b/Rhino.ServiceBus.Tests/Rhino.ServiceBus.Tests.csproj
@@ -138,6 +138,7 @@
     <Compile Include="Containers\Autofac\Can_host_in_another_app_domain.cs" />
     <Compile Include="Containers\Autofac\ContainerTests.cs" />
     <Compile Include="Containers\Autofac\QueueCreationTests.cs" />
+    <Compile Include="Containers\Castle\ContainerTests.cs" />
     <Compile Include="Containers\Spring\Can_host_in_another_app_domain.cs" />
     <Compile Include="Containers\Spring\ContainerTests.cs" />
     <Compile Include="Containers\StructureMap\Can_host_in_another_app_domain.cs" />


### PR DESCRIPTION
Under Castle Windsor, message consumers are now resolved using the release policy configured for the container, which (in case of LifecycledComponentsReleasePolicy) enables tracking and proper cleanup of them and their dependencies.
