### PR TITLE
Dispose not being called when stopping service

### DIFF
--- a/Rhino.ServiceBus.Host/RhinoServiceBusHost.cs
+++ b/Rhino.ServiceBus.Host/RhinoServiceBusHost.cs
@@ -31,26 +31,24 @@ namespace Rhino.ServiceBus.Host
 
         protected override void OnStart(string[] ignored)
         {
-            RemoteAppDomainHost remoteAppDomainHost;
-
             if (string.IsNullOrEmpty(bootStrapper) == false)
             {
                 var assembly = LoadAssembly();
                 var bootStrapperType = LoadBootStrapperType(assembly);
-                remoteAppDomainHost = new RemoteAppDomainHost(bootStrapperType);
-                remoteAppDomainHost.Configuration(cfg);
+                host = new RemoteAppDomainHost(bootStrapperType);
+                host.Configuration(cfg);
             }
             else
             {
-                remoteAppDomainHost = new RemoteAppDomainHost(asm, cfg);
+                host = new RemoteAppDomainHost(asm, cfg);
             }
 
             if (string.IsNullOrEmpty(hostType) == false)
             {
-                remoteAppDomainHost.SetHostType(hostType);
+                host.SetHostType(hostType);
             }
 
-            remoteAppDomainHost.Start();
+            host.Start();
         }
 
         private Assembly LoadAssembly()


### PR DESCRIPTION
Found a bug where the host instance variable inside of the
RhinoServiceBusHost was never being set anymore.  This was resulting in
dispose not being called when the service was stopped.

It looks like this was introduced in commit cafe6758c05368607738226012bf7752dcb1bc06
