### PR TITLE
Added support for delivery options in Rhino.Queues

### DIFF
--- a/Rhino.ServiceBus.Spring/SpringBuilder.cs
+++ b/Rhino.ServiceBus.Spring/SpringBuilder.cs
@@ -220,7 +220,9 @@ namespace Rhino.ServiceBus.Spring
                                                                                                                                     busConfig.EnablePerformanceCounters,
                                                                                                                                     applicationContext.Get<IMessageBuilder<MessagePayload>>()));
 
-            applicationContext.RegisterSingleton<IMessageBuilder<MessagePayload>>(() => new RhinoQueuesMessageBuilder(applicationContext.Get<IMessageSerializer>()));
+            applicationContext.RegisterSingleton<IMessageBuilder<MessagePayload>>(() => new RhinoQueuesMessageBuilder(
+                applicationContext.Get<IMessageSerializer>(),
+                applicationContext.Get<IServiceLocator>()));
         }
 
         public void RegisterRhinoQueuesOneWay()
@@ -228,7 +230,9 @@ namespace Rhino.ServiceBus.Spring
             var oneWayConfig = (OnewayRhinoServiceBusConfiguration) config;
             var busConfig = config.ConfigurationSection.Bus;
 
-            applicationContext.RegisterSingleton<IMessageBuilder<MessagePayload>>(() => new RhinoQueuesMessageBuilder(applicationContext.Get<IMessageSerializer>()));
+            applicationContext.RegisterSingleton<IMessageBuilder<MessagePayload>>(() => new RhinoQueuesMessageBuilder(
+                applicationContext.Get<IMessageSerializer>(),
+                applicationContext.Get<IServiceLocator>()));
             applicationContext.RegisterSingleton<IOnewayBus>(() => new RhinoQueuesOneWayBus(oneWayConfig.MessageOwners, applicationContext.Get<IMessageSerializer>(), busConfig.QueuePath, busConfig.EnablePerformanceCounters, applicationContext.Get<IMessageBuilder<MessagePayload>>()));
         }
 

--- a/Rhino.ServiceBus.Tests/Bugs/FIeldProblem_Nick.cs
+++ b/Rhino.ServiceBus.Tests/Bugs/FIeldProblem_Nick.cs
@@ -42,24 +42,29 @@ namespace Rhino.ServiceBus.Tests.Bugs
                 subscriptionStorage.HandleAdministrativeMessage;
 
             Message msg = new MsmqMessageBuilder
-                (serializer, new CastleServiceLocator(new WindsorContainer())).BuildFromMessageBatch(new
-                                                                     AddInstanceSubscription
+                (serializer, new CastleServiceLocator(new WindsorContainer())).BuildFromMessageBatch(
+                new OutgoingMessageInformation
                 {
-                    Endpoint = queueEndpoint.Uri.ToString(),
-                    InstanceSubscriptionKey = id,
-                    Type = typeof (TestMessage2).FullName,
+                    Messages = new[] { new AddInstanceSubscription
+                    {
+                        Endpoint = queueEndpoint.Uri.ToString(),
+                        InstanceSubscriptionKey = id,
+                        Type = typeof (TestMessage2).FullName,
+                    }}
                 });
             send(msg);
 
             wait.WaitOne();
 
             msg = new MsmqMessageBuilder
-                (serializer, new CastleServiceLocator(new WindsorContainer())).BuildFromMessageBatch(new
-                                                                     RemoveInstanceSubscription
+                (serializer, new CastleServiceLocator(new WindsorContainer())).BuildFromMessageBatch(new OutgoingMessageInformation
                 {
-                    Endpoint = queueEndpoint.Uri.ToString(),
-                    InstanceSubscriptionKey = id,
-                    Type = typeof (TestMessage2).FullName,
+                    Messages = new[] { new RemoveInstanceSubscription
+                    {
+                        Endpoint = queueEndpoint.Uri.ToString(),
+                        InstanceSubscriptionKey = id,
+                        Type = typeof (TestMessage2).FullName,
+                    }}
                 });
            
             wait.Reset();

--- a/Rhino.ServiceBus.Tests/CanCustomizeHeadersWithMsmq.cs
+++ b/Rhino.ServiceBus.Tests/CanCustomizeHeadersWithMsmq.cs
@@ -21,7 +21,7 @@ namespace Rhino.ServiceBus.Tests
         {
             using (var container = new WindsorContainer())
             {
-                container.Register(Component.For<ICustomizeMessageHeaders>().ImplementedBy<AppIdentityCustomizer>().LifeStyle.Is(LifestyleType.Transient));
+                container.Register(Component.For<ICustomizeOutgoingMessages>().ImplementedBy<AppIdentityCustomizer>().LifeStyle.Is(LifestyleType.Transient));
                 new RhinoServiceBusConfiguration()
                     .UseCastleWindsor(container)
                     .Configure();
@@ -45,7 +45,7 @@ namespace Rhino.ServiceBus.Tests
         {
             using (var container = new WindsorContainer(new XmlInterpreter()))
             {
-                container.Register(Component.For<ICustomizeMessageHeaders>().ImplementedBy<AppIdentityCustomizer>().LifeStyle.Is(LifestyleType.Transient));
+                container.Register(Component.For<ICustomizeOutgoingMessages>().ImplementedBy<AppIdentityCustomizer>().LifeStyle.Is(LifestyleType.Transient));
                 new RhinoServiceBusConfiguration()
                     .UseCastleWindsor(container)
                     .Configure();
@@ -77,11 +77,11 @@ namespace Rhino.ServiceBus.Tests
             }
         }
 
-        public class AppIdentityCustomizer : ICustomizeMessageHeaders
+        public class AppIdentityCustomizer : ICustomizeOutgoingMessages
         {
-            public void Customize(NameValueCollection headers)
+            public void Customize(OutgoingMessageInformation messageInformation)
             {
-                headers.Add("user-id", "corey");
+                messageInformation.Headers.Add("user-id", "corey");
             }
         }
     }

--- a/Rhino.ServiceBus.Tests/CanSendMsgsFromOneWayBusUsingRhinoQueues.cs
+++ b/Rhino.ServiceBus.Tests/CanSendMsgsFromOneWayBusUsingRhinoQueues.cs
@@ -51,17 +51,18 @@ namespace Rhino.ServiceBus.Tests
                 bus.Start();
 
                 using (var oneWay = new RhinoQueuesOneWayBus(
-                                                new[]{
-                                                     new MessageOwner
-                                                         {
-                                                             Endpoint = bus.Endpoint.Uri,
-                                                             Name = "System",
-                                                         },
-                                                    }, 
-                                                 container.Resolve<IMessageSerializer>(),
-                                                 Path.Combine(Path.GetFullPath(AppDomain.CurrentDomain.BaseDirectory), "one_way.esent"),
-                                                 false,
-                                                 new RhinoQueuesMessageBuilder(container.Resolve<IMessageSerializer>())))
+                    new[]{
+                            new MessageOwner
+                                {
+                                    Endpoint = bus.Endpoint.Uri,
+                                    Name = "System",
+                                },
+                        }, 
+                        container.Resolve<IMessageSerializer>(),
+                        Path.Combine(Path.GetFullPath(AppDomain.CurrentDomain.BaseDirectory), "one_way.esent"),
+                        false,
+                        new RhinoQueuesMessageBuilder(container.Resolve<IMessageSerializer>(),
+                            container.Resolve<IServiceLocator>())))
                 {
                     oneWay.Send("hello there, one way");
 

--- a/Rhino.ServiceBus.Tests/RhinoQueues/UsingRhinoQueuesTransport.cs
+++ b/Rhino.ServiceBus.Tests/RhinoQueues/UsingRhinoQueuesTransport.cs
@@ -25,8 +25,8 @@ namespace Rhino.ServiceBus.Tests.RhinoQueues
             if (Directory.Exists("test.esent"))
                 Directory.Delete("test.esent", true);
 
-            messageSerializer = new XmlMessageSerializer(new DefaultReflection(),
-                                                      new CastleServiceLocator(new WindsorContainer()));
+            var serviceLocator = new CastleServiceLocator(new WindsorContainer());
+            messageSerializer = new XmlMessageSerializer(new DefaultReflection(), serviceLocator);
             transport = new RhinoQueuesTransport(
                 new Uri("rhino.queues://localhost:23456/q"),
                 new EndpointRouter(),
@@ -36,7 +36,7 @@ namespace Rhino.ServiceBus.Tests.RhinoQueues
                 IsolationLevel.Serializable, 
                 5,
                 false,
-                new RhinoQueuesMessageBuilder(messageSerializer)
+                new RhinoQueuesMessageBuilder(messageSerializer, serviceLocator)
                 );
             transport.Start();
         }

--- a/Rhino.ServiceBus.Tests/RhinoQueues/WhenErrorOccurs.cs
+++ b/Rhino.ServiceBus.Tests/RhinoQueues/WhenErrorOccurs.cs
@@ -30,8 +30,9 @@ namespace Rhino.ServiceBus.Tests.RhinoQueues
         [Fact]
         public void Deserialization_Error_Will_Not_Retry()
         {
+            var serviceLocator = new CastleServiceLocator(new WindsorContainer());
             messageSerializer = new ThrowingSerializer(new XmlMessageSerializer(new DefaultReflection(),
-                                                      new CastleServiceLocator(new WindsorContainer())));
+                                                      serviceLocator));
             transport = new RhinoQueuesTransport(
                 new Uri("rhino.queues://localhost:23456/q"),
                 new EndpointRouter(),
@@ -41,7 +42,7 @@ namespace Rhino.ServiceBus.Tests.RhinoQueues
                 IsolationLevel.Serializable,
                 5,
                 false,
-                new RhinoQueuesMessageBuilder(messageSerializer)
+                new RhinoQueuesMessageBuilder(messageSerializer, serviceLocator)
                 );
             transport.Start();
             var count = 0;
@@ -59,8 +60,8 @@ namespace Rhino.ServiceBus.Tests.RhinoQueues
         [Fact]
         public void Arrived_Error_Will_Retry_Number_Of_Times_Configured()
         {
-            messageSerializer = new XmlMessageSerializer(new DefaultReflection(),
-                                                      new CastleServiceLocator(new WindsorContainer()));
+            var serviceLocator = new CastleServiceLocator(new WindsorContainer());
+            messageSerializer = new XmlMessageSerializer(new DefaultReflection(), serviceLocator);
             transport = new RhinoQueuesTransport(
                 new Uri("rhino.queues://localhost:23456/q"),
                 new EndpointRouter(),
@@ -70,7 +71,7 @@ namespace Rhino.ServiceBus.Tests.RhinoQueues
                 IsolationLevel.Serializable,
                 5,
                 false,
-                new RhinoQueuesMessageBuilder(messageSerializer)
+                new RhinoQueuesMessageBuilder(messageSerializer, serviceLocator)
                 );
             transport.Start();
             var count = 0;

--- a/Rhino.ServiceBus.Tests/RhinoQueues/WhenReceivingTimedMessage.cs
+++ b/Rhino.ServiceBus.Tests/RhinoQueues/WhenReceivingTimedMessage.cs
@@ -22,8 +22,9 @@ namespace Rhino.ServiceBus.Tests.RhinoQueues
             if (Directory.Exists("test.esent"))
                 Directory.Delete("test.esent", true);
 
+            var serviceLocator = new CastleServiceLocator(new WindsorContainer());
             messageSerializer = new XmlMessageSerializer(new DefaultReflection(),
-                new CastleServiceLocator(new WindsorContainer()));
+                serviceLocator);
             transport = new RhinoQueuesTransport(
                 new Uri("rhino.queues://localhost:23456/q"),
                 new EndpointRouter(),
@@ -33,7 +34,7 @@ namespace Rhino.ServiceBus.Tests.RhinoQueues
                 IsolationLevel.Serializable,
                 5,
                 false,
-                new RhinoQueuesMessageBuilder(messageSerializer)
+                new RhinoQueuesMessageBuilder(messageSerializer, serviceLocator)
                 );
             transport.Start();
         }

--- a/Rhino.ServiceBus/ICustomizeMessageHeaders.cs
+++ b/Rhino.ServiceBus/ICustomizeMessageHeaders.cs
@@ -1,9 +1,0 @@
-using System.Collections.Specialized;
-
-namespace Rhino.ServiceBus
-{
-    public interface ICustomizeMessageHeaders
-    {
-        void Customize(NameValueCollection headers);
-    }
-}

--- a/Rhino.ServiceBus/ICustomizeOutgoingMessages.cs
+++ b/Rhino.ServiceBus/ICustomizeOutgoingMessages.cs
@@ -1,0 +1,7 @@
+namespace Rhino.ServiceBus
+{
+    public interface ICustomizeOutgoingMessages
+    {
+        void Customize(OutgoingMessageInformation messageInformation);
+    }
+}

--- a/Rhino.ServiceBus/Impl/MessageOwnersSelector.cs
+++ b/Rhino.ServiceBus/Impl/MessageOwnersSelector.cs
@@ -33,7 +33,7 @@ namespace Rhino.ServiceBus.Impl
                 .FirstOrDefault();
 
             if (messageOwner == null)
-                throw new MessagePublicationException("Could not find no message owner for " + messages[0]);
+                throw new MessagePublicationException("Could not find a message owner for " + messages[0]);
 
             var endpoint = endpointRouter.GetRoutedEndpoint(messageOwner.Endpoint);
             endpoint.Transactional = messageOwner.Transactional;

--- a/Rhino.ServiceBus/Internal/IMessageBuilder.cs
+++ b/Rhino.ServiceBus/Internal/IMessageBuilder.cs
@@ -5,7 +5,7 @@ namespace Rhino.ServiceBus.Internal
     public interface IMessageBuilder<T>
     {
         event Action<T> MessageBuilt;
-        T BuildFromMessageBatch(params object[] msgs);
+        T BuildFromMessageBatch(OutgoingMessageInformation messageInformation);
         void Initialize(Endpoint source);
     }
 }

--- a/Rhino.ServiceBus/LoadBalancer/MsmqSecondaryLoadBalancer.cs
+++ b/Rhino.ServiceBus/LoadBalancer/MsmqSecondaryLoadBalancer.cs
@@ -89,9 +89,7 @@ namespace Rhino.ServiceBus.LoadBalancer
             {
                 logger.InfoFormat("Notifying worker {0} that secondary load balancer {1} is accepting work on awating listenerQueue",
                    queueUri,
-                   newEndpoint,
-                   originalEndPoint
-                   );
+                   newEndpoint);
 
                 SendToQueue(queueUri,
                     new Reroute
@@ -105,9 +103,7 @@ namespace Rhino.ServiceBus.LoadBalancer
             {
                 logger.InfoFormat("Notifying worker {0} that secondary load balancer {1} is accepting work",
                    queueUri,
-                   Endpoint.Uri,
-                   PrimaryLoadBalancer
-                   );
+                   Endpoint.Uri);
 
                 SendToQueue(queueUri,
                     new AcceptingWork

--- a/Rhino.ServiceBus/Msmq/AbstractMsmqListener.cs
+++ b/Rhino.ServiceBus/Msmq/AbstractMsmqListener.cs
@@ -273,7 +273,17 @@ namespace Rhino.ServiceBus.Msmq
 
         protected Message GenerateMsmqMessageFromMessageBatch(params object[] msgs)
         {
-            return messageBuilder.BuildFromMessageBatch(msgs);
+            var messageInformation = new OutgoingMessageInformation
+            {
+                Messages = msgs,
+                Source = Endpoint
+            };
+            return GenerateMsmqMessageFromMessageBatch(messageInformation);
+        }
+
+        protected Message GenerateMsmqMessageFromMessageBatch(OutgoingMessageInformation messageInformation)
+        {
+            return messageBuilder.BuildFromMessageBatch(messageInformation);
         }
 
         protected object[] DeserializeMessages(OpenedQueue messageQueue, Message transportMessage, Action<CurrentMessageInformation, Exception> messageSerializationException)

--- a/Rhino.ServiceBus/Msmq/MsmqOnewayBus.cs
+++ b/Rhino.ServiceBus/Msmq/MsmqOnewayBus.cs
@@ -18,9 +18,14 @@ namespace Rhino.ServiceBus.Msmq
         public void Send(params object[] msgs)
         {
             var endpoint = messageOwners.GetEndpointForMessageBatch(msgs);
+            var messageInformation = new OutgoingMessageInformation
+            {
+                Destination = endpoint,
+                Messages = msgs,
+            };
             using(var queue = endpoint.InitalizeQueue())
             {
-                var message = messageBuilder.BuildFromMessageBatch(msgs);
+                var message = messageBuilder.BuildFromMessageBatch(messageInformation);
                 queue.SendInSingleTransaction(message);
             }
         }

--- a/Rhino.ServiceBus/Msmq/MsmqTransport.cs
+++ b/Rhino.ServiceBus/Msmq/MsmqTransport.cs
@@ -111,8 +111,14 @@ namespace Rhino.ServiceBus.Msmq
 		{
 			if (HaveStarted == false)
 				throw new InvalidOperationException("Cannot send a message before transport is started");
-			
-			var message = GenerateMsmqMessageFromMessageBatch(msgs);
+
+            var messageInformation = new OutgoingMessageInformation
+            {
+                Destination = endpoint,
+                Messages = msgs,
+                Source = Endpoint
+            };
+			var message = GenerateMsmqMessageFromMessageBatch(messageInformation);
 	        var processAgainBytes = BitConverter.GetBytes(processAgainAt.ToBinary());
             if (message.Extension.Length == 16)
             {
@@ -136,7 +142,13 @@ namespace Rhino.ServiceBus.Msmq
 			if(HaveStarted==false)
 				throw new InvalidOperationException("Cannot send a message before transport is started");
 
-			var message = GenerateMsmqMessageFromMessageBatch(msgs);
+            var messageInformation = new OutgoingMessageInformation
+            {
+                Destination = destination,
+                Messages = msgs,
+                Source = Endpoint
+            };
+            var message = GenerateMsmqMessageFromMessageBatch(messageInformation);
 
             SendMessageToQueue(message, destination);
 

--- a/Rhino.ServiceBus/OutgoingMessageInformation.cs
+++ b/Rhino.ServiceBus/OutgoingMessageInformation.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Specialized;
+
+namespace Rhino.ServiceBus
+{
+    public class OutgoingMessageInformation
+    {
+        public DateTime? DeliverBy { get; set; }
+
+        /// <summary>
+        /// The destination the messages will be sent to.  This may be null if the 
+        /// messages are being sent to multiple endpoints.
+        /// </summary>
+        public Endpoint Destination { get; set; }
+
+        public NameValueCollection Headers { get; set; }
+        public int? MaxAttempts { get; set; }
+        public object[] Messages { get; set; }
+
+        /// <summary>
+        /// The current endpoint.  This may be null on a one-way bus.
+        /// </summary>
+        public Endpoint Source { get; set; }
+    }
+}

--- a/Rhino.ServiceBus/Rhino.ServiceBus.csproj
+++ b/Rhino.ServiceBus/Rhino.ServiceBus.csproj
@@ -175,7 +175,7 @@
     <Compile Include="Hosting\AbstractBootStrapper.cs" />
     <Compile Include="Hosting\DefaultHost.cs" />
     <Compile Include="Hosting\RemoteAppDomainHost.cs" />
-    <Compile Include="ICustomizeMessageHeaders.cs" />
+    <Compile Include="ICustomizeOutgoingMessages.cs" />
     <Compile Include="Impl\DefaultHandler.cs" />
     <Compile Include="Impl\EndpointRouter.cs" />
     <Compile Include="Endpoint.cs" />
@@ -202,6 +202,7 @@
     <Compile Include="Messages\ReadyToWork.cs" />
     <Compile Include="Msmq\AbstractMsmqListener.cs" />
     <Compile Include="Msmq\QueueCreationModule.cs" />
+    <Compile Include="OutgoingMessageInformation.cs" />
     <Compile Include="RhinoQueues\RhinoQueuesMessageBuilder.cs" />
     <Compile Include="RhinoQueues\RhinoQueuesOneWayBus.cs" />
     <Compile Include="ServiceBusExtensions.cs" />

--- a/Rhino.ServiceBus/RhinoQueues/RhinoQueuesTransport.cs
+++ b/Rhino.ServiceBus/RhinoQueues/RhinoQueuesTransport.cs
@@ -471,7 +471,13 @@ namespace Rhino.ServiceBus.RhinoQueues
         private void SendInternal(object[] msgs, Endpoint destination, Action<NameValueCollection> customizeHeaders)
         {
             var messageId = Guid.NewGuid();
-            var payload = messageBuilder.BuildFromMessageBatch(msgs);
+            var messageInformation = new OutgoingMessageInformation
+            {
+                Destination = destination,
+                Messages = msgs,
+                Source = Endpoint
+            };
+            var payload = messageBuilder.BuildFromMessageBatch(messageInformation);
             logger.DebugFormat("Sending a message with id '{0}' to '{1}'", messageId, destination.Uri);
             customizeHeaders(payload.Headers);
             var transactionOptions = GetTransactionOptions();


### PR DESCRIPTION
Refactored to use ICustomizeOutgoingMessages and OutgoingMessageInformation when building messages.  This is a breaking change from ICustomizeMessageHeaders.  The Rhino.Queues reference in SharedLibs hasn't been updated in this pull request.
