### PR TITLE
Shutdown improvements

### DIFF
--- a/Rhino.ServiceBus.Tests/CanCustomizeOutgoingMessagesWithMsmq.cs
+++ b/Rhino.ServiceBus.Tests/CanCustomizeOutgoingMessagesWithMsmq.cs
@@ -108,6 +108,7 @@ namespace Rhino.ServiceBus.Tests
         {
             using (var container = new WindsorContainer())
             {
+                MaxAttemptCustomizer.MaxAttempts = 1;
                 container.Register(Component.For<ICustomizeOutgoingMessages>()
                     .ImplementedBy<MaxAttemptCustomizer>()
                     .LifeStyle.Is(LifestyleType.Transient));


### PR DESCRIPTION
- RhinoQueuesTransport will drain message consumers during disposal.

I removed the exception logging commit after I rebased since it's already been done.
