### PR TITLE
Load balancer working on XP/2003

### DIFF
--- a/Rhino.ServiceBus/LoadBalancer/MsmqLoadBalancer.cs
+++ b/Rhino.ServiceBus/LoadBalancer/MsmqLoadBalancer.cs
@@ -478,7 +478,7 @@ namespace Rhino.ServiceBus.LoadBalancer
 				Body = work.Endpoint.ToString(),
 				Label = ("Known worker: " + work.Endpoint).EnsureLabelLength()
 			};
-			logger.DebugFormat("New worker: {0}", work.Endpoint);
+			logger.InfoFormat("New worker: {0}", work.Endpoint);
 			queue.Send(persistedWorker.SetSubQueueToSendTo(SubQueue.Workers));
 
 			SendToQueue(secondaryLoadBalancer, new NewWorkerPersisted

--- a/Rhino.ServiceBus/LoadBalancer/MsmqLoadBalancer.cs
+++ b/Rhino.ServiceBus/LoadBalancer/MsmqLoadBalancer.cs
@@ -118,7 +118,7 @@ namespace Rhino.ServiceBus.LoadBalancer
 		private void ReadUrisFromSubQueue(Set<Uri> set, SubQueue subQueue)
 		{
 			using (var q = MsmqUtil.GetQueuePath(Endpoint).Open(QueueAccessMode.Receive))
-			using (var sq = q.OpenSubQueue(subQueue, QueueAccessMode.SendAndReceive))
+			using (var sq = this.queueStrategy.OpenSubQueue(q, subQueue, QueueAccessMode.SendAndReceive))
 			{
 				var messages = sq.GetAllMessagesWithStringFormatter();
 				foreach (var message in messages)

--- a/Rhino.ServiceBus/Msmq/FlatQueueStrategy.cs
+++ b/Rhino.ServiceBus/Msmq/FlatQueueStrategy.cs
@@ -173,6 +173,11 @@ namespace Rhino.ServiceBus.Msmq
     		}
     	}
 
+        public OpenedQueue OpenSubQueue(OpenedQueue queue, SubQueue subQueue, QueueAccessMode accessMode)
+        {
+            return queue.OpenSiblngQueue(subQueue, accessMode);
+        }
+
     	/// <summary>
         /// Gets the errors queue path.
         /// </summary>

--- a/Rhino.ServiceBus/Msmq/FlatQueueStrategy.cs
+++ b/Rhino.ServiceBus/Msmq/FlatQueueStrategy.cs
@@ -67,6 +67,11 @@ namespace Rhino.ServiceBus.Msmq
 	                    MsmqUtil.OpenOrCreateQueue(GetKnownWorkersQueuePath(), QueueAccessMode.SendAndReceive, queue),
 	                    MsmqUtil.OpenOrCreateQueue(GetKnownEndpointsQueuePath(), QueueAccessMode.SendAndReceive, queue),
 	                };
+                case QueueType.Raw:
+                    return new[]
+	                {
+	                    queue,
+	                };
                 default:
                     throw new ArgumentOutOfRangeException("queueType", "Can't handle queue type: " + queueType);
             }

--- a/Rhino.ServiceBus/Msmq/IQueueStrategy.cs
+++ b/Rhino.ServiceBus/Msmq/IQueueStrategy.cs
@@ -36,5 +36,7 @@ namespace Rhino.ServiceBus.Msmq
 		bool TryMoveMessage(OpenedQueue queue, Message message, SubQueue subQueue, out string msgId);
 
 		void SendToErrorQueue(OpenedQueue queue, Message message);
+
+        OpenedQueue OpenSubQueue(OpenedQueue queue, SubQueue subQueue, QueueAccessMode accessMode);
     }
 }

--- a/Rhino.ServiceBus/Msmq/SubQueueStrategy.cs
+++ b/Rhino.ServiceBus/Msmq/SubQueueStrategy.cs
@@ -91,5 +91,10 @@ namespace Rhino.ServiceBus.Msmq
 		{
 			queue.Send(message);
 		}
+
+        public OpenedQueue OpenSubQueue(OpenedQueue queue, SubQueue subQueue, QueueAccessMode accessMode)
+        {
+            return queue.OpenSubQueue(subQueue, accessMode);
+        }
 	}
 }

--- a/Samples/Starbucks.Tests/IntegrationTest.cs
+++ b/Samples/Starbucks.Tests/IntegrationTest.cs
@@ -21,7 +21,7 @@ namespace Starbucks.Tests
         public IntegrationTest()
         {
             PrepareQueues.Prepare("msmq://localhost/starbucks.barista.balancer", QueueType.LoadBalancer);
-            PrepareQueues.Prepare("msmq://localhost/starbucks.barista.balancer.acceptingwork", QueueType.LoadBalancer);
+            PrepareQueues.Prepare("msmq://localhost/starbucks.barista.balancer.acceptingwork", QueueType.Raw);
             PrepareQueues.Prepare("msmq://localhost/starbucks.barista", QueueType.Standard);
             PrepareQueues.Prepare("msmq://localhost/starbucks.cashier", QueueType.Standard);
             PrepareQueues.Prepare("msmq://localhost/starbucks.customer", QueueType.Standard);

--- a/Samples/Starbucks/PrepareQueues.cs
+++ b/Samples/Starbucks/PrepareQueues.cs
@@ -49,6 +49,9 @@ namespace Starbucks
                     PurgeSubqueue(queuePath, "endpoints");
                     PurgeSubqueue(queuePath, "workers");
                     break;
+                case QueueType.Raw:
+                    // no subqueues here
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException("queueType", "Can't handle queue type: " + queueType);
             }

--- a/Samples/Starbucks/Program.cs
+++ b/Samples/Starbucks/Program.cs
@@ -15,7 +15,7 @@ namespace Starbucks
         public static void Main()
         {
             PrepareQueues.Prepare("msmq://localhost/starbucks.barista.balancer", QueueType.LoadBalancer);
-            PrepareQueues.Prepare("msmq://localhost/starbucks.barista.balancer.acceptingwork", QueueType.LoadBalancer);
+            PrepareQueues.Prepare("msmq://localhost/starbucks.barista.balancer.acceptingwork", QueueType.Raw);
             PrepareQueues.Prepare("msmq://localhost/starbucks.barista", QueueType.Standard);
             PrepareQueues.Prepare("msmq://localhost/starbucks.cashier", QueueType.Standard);
             PrepareQueues.Prepare("msmq://localhost/starbucks.customer", QueueType.Standard);


### PR DESCRIPTION
MSMQ load balancer reads its queues using IQueueStrategy. This enables support for Windows XP/2003 (MSMQ 3.0 - no subqueues).

Also fixed load balancer queue creation upon deployment on XP/2003.
