### PR TITLE
Make sure .NET 4.0 is targeted when 4.5 is present

### DIFF
--- a/default.ps1
+++ b/default.ps1
@@ -58,12 +58,12 @@ task Compile -depends Init {
   msbuild $sln_file /target:Rebuild /p:"OutDir=$35_build_dir\x86\UAC\;Configuration=$config;Platform=x86;TargetFrameworkVersion=V3.5;LibDir=$35_lib_dir;ApplicationManifest=$base_dir\Rhino.ServiceBus.manifest"
   msbuild $sln_file /target:Rebuild /p:"OutDir=$35_build_dir\x64\;Configuration=$config;Platform=x64;TargetFrameworkVersion=V3.5;LibDir=$35_lib_dir"
   msbuild $sln_file /target:Rebuild /p:"OutDir=$35_build_dir\x64\UAC\;Configuration=$config;Platform=x64;TargetFrameworkVersion=V3.5;LibDir=$35_lib_dir;ApplicationManifest=$base_dir\Rhino.ServiceBus.manifest"
-  msbuild $sln_file /target:Rebuild /p:"OutDir=$40_build_dir;Configuration=$config;TargetFrameworkVersion=4.0"
-  msbuild $sln_file /target:Rebuild /p:"OutDir=$40_build_dir\UAC\;Configuration=$config;TargetFrameworkVersion=4.0;ApplicationManifest=$base_dir\Rhino.ServiceBus.manifest"
-  msbuild $sln_file /target:Rebuild /p:"OutDir=$40_build_dir\x86\;Configuration=$config;Platform=x86;TargetFrameworkVersion=4.0"
-  msbuild $sln_file /target:Rebuild /p:"OutDir=$40_build_dir\x86\UAC\;Configuration=$config;Platform=x86;TargetFrameworkVersion=4.0;ApplicationManifest=$base_dir\Rhino.ServiceBus.manifest"
-  msbuild $sln_file /target:Rebuild /p:"OutDir=$40_build_dir\x64\;Configuration=$config;Platform=x64;TargetFrameworkVersion=4.0"
-  msbuild $sln_file /target:Rebuild /p:"OutDir=$40_build_dir\x64\UAC\;Configuration=$config;Platform=x64;TargetFrameworkVersion=4.0;ApplicationManifest=$base_dir\Rhino.ServiceBus.manifest"
+  msbuild $sln_file /target:Rebuild /p:"OutDir=$40_build_dir;Configuration=$config;TargetFrameworkVersion=V4.0"
+  msbuild $sln_file /target:Rebuild /p:"OutDir=$40_build_dir\UAC\;Configuration=$config;TargetFrameworkVersion=V4.0;ApplicationManifest=$base_dir\Rhino.ServiceBus.manifest"
+  msbuild $sln_file /target:Rebuild /p:"OutDir=$40_build_dir\x86\;Configuration=$config;Platform=x86;TargetFrameworkVersion=V4.0"
+  msbuild $sln_file /target:Rebuild /p:"OutDir=$40_build_dir\x86\UAC\;Configuration=$config;Platform=x86;TargetFrameworkVersion=V4.0;ApplicationManifest=$base_dir\Rhino.ServiceBus.manifest"
+  msbuild $sln_file /target:Rebuild /p:"OutDir=$40_build_dir\x64\;Configuration=$config;Platform=x64;TargetFrameworkVersion=V4.0"
+  msbuild $sln_file /target:Rebuild /p:"OutDir=$40_build_dir\x64\UAC\;Configuration=$config;Platform=x64;TargetFrameworkVersion=V4.0;ApplicationManifest=$base_dir\Rhino.ServiceBus.manifest"
 }
 
 task Test -depends Compile -precondition { return $run_tests }{


### PR DESCRIPTION
"4.0" is not a valid value of TargetFrameworkVersion. Apparently, an invalid value is silently ignored and causes msbuild to target the newest framework installed on the machine. 

On a computer with Visual Studio 2012 installed, .NET 4.5 is targeted. Unfortunately, 4.5 drops support for XP/2003. The generated Rhino.ServiceBus.Host.exe specifies a minimum OS of Vista/2008 in its PE header and refuses to load on XP/2003.

When "V4.0" is specified as TargetFrameworkVersion, .NET 4.0 is correctly targeted and the exe works on XP/2003.
