### PR TITLE
Added explicit version numbers to Rhino.* dependencies in nuget packages...

### DIFF
--- a/packaging/rhino.servicebus.autofac.nuspec
+++ b/packaging/rhino.servicebus.autofac.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>Rhino.ServiceBus.Autofac</id>
-    <version>0.0.0</version>
+    <version>$version$</version>
     <authors>Steve Wagner, Corey Kaylor</authors>
     <owners>Corey Kaylor</owners>
     <licenseUrl>https://raw.github.com/hibernating-rhinos/rhino-esb/master/license.txt</licenseUrl>
@@ -12,7 +12,7 @@
     <description>Autofac integration with Rhino.ServiceBus</description>
     <tags>rhino autofac servicebus bus msmq messaging cqrs</tags>
     <dependencies>
-      <dependency id="Rhino.ServiceBus"/>
+      <dependency id="Rhino.ServiceBus" version="$version$"/>
       <dependency id="Autofac" version="[2.5.2.830]"/>
     </dependencies>
   </metadata>

--- a/packaging/rhino.servicebus.castle.nuspec
+++ b/packaging/rhino.servicebus.castle.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>Rhino.ServiceBus.Castle</id>
-    <version>0.0.0</version>
+    <version>$version$</version>
     <authors>Corey Kaylor</authors>
     <owners>Corey Kaylor</owners>
     <licenseUrl>https://raw.github.com/hibernating-rhinos/rhino-esb/master/license.txt</licenseUrl>
@@ -14,7 +14,7 @@
     <dependencies>
       <dependency id="Castle.Core" version="3.1.0" />
       <dependency id="Castle.Windsor" version="3.1.0" />
-      <dependency id="Rhino.ServiceBus"/>
+      <dependency id="Rhino.ServiceBus" version="$version$"/>
     </dependencies>
   </metadata>
   <files>

--- a/packaging/rhino.servicebus.host.nuspec
+++ b/packaging/rhino.servicebus.host.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>Rhino.ServiceBus.Host</id>
-    <version>0.0.0</version>
+    <version>$version$</version>
     <authors>Ayende Rahien, Corey Kaylor</authors>
     <owners>Corey Kaylor</owners>
     <licenseUrl>https://raw.github.com/hibernating-rhinos/rhino-esb/master/license.txt</licenseUrl>
@@ -12,7 +12,7 @@
     <description>Host for Rhino.ServiceBus</description>
     <tags>rhino host servicebus bus msmq messaging cqrs</tags>
     <dependencies>
-      <dependency id="Rhino.ServiceBus"/>
+      <dependency id="Rhino.ServiceBus" version="$version$"/>
     </dependencies>
   </metadata>
   <files>

--- a/packaging/rhino.servicebus.nuspec
+++ b/packaging/rhino.servicebus.nuspec
@@ -3,7 +3,7 @@
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>Rhino.ServiceBus</id>
     <title>Rhino.ServiceBus</title>
-    <version>0.0.0</version>
+    <version>$version$</version>
     <authors>Ayende Rahien, Corey Kaylor</authors>
     <owners>Corey Kaylor</owners>
     <licenseUrl>https://raw.github.com/hibernating-rhinos/rhino-esb/master/license.txt</licenseUrl>

--- a/packaging/rhino.servicebus.references.nuspec
+++ b/packaging/rhino.servicebus.references.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>Rhino.ServiceBus.References</id>
-    <version>0.0.0</version>
+    <version>$version$</version>
     <authors>Ayende Rahien, Corey Kaylor</authors>
     <owners>Corey Kaylor</owners>
     <licenseUrl>https://raw.github.com/hibernating-rhinos/rhino-esb/master/license.txt</licenseUrl>

--- a/packaging/rhino.servicebus.rhinoqueues.nuspec
+++ b/packaging/rhino.servicebus.rhinoqueues.nuspec
@@ -3,7 +3,7 @@
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>Rhino.ServiceBus.RhinoQueues</id>
     <title>Rhino.ServiceBus.RhinoQueues</title>
-    <version>0.0.0</version>
+    <version>$version$</version>
     <authors>Ayende Rahien, Corey Kaylor</authors>
     <owners>Corey Kaylor</owners>
     <licenseUrl>https://raw.github.com/hibernating-rhinos/rhino-esb/master/license.txt</licenseUrl>
@@ -13,10 +13,10 @@
     <description>A developer friendly service bus for .NET</description>
     <tags>rhino servicebus bus msmq messaging cqrs async queue publish subscribe pub sub</tags>
     <dependencies>
-      <dependency id="Rhino.ServiceBus.References"/>
-      <dependency id="Rhino.PersistentHashTable"/>
-      <dependency id="Rhino.ServiceBus"/>
-      <dependency id="Rhino.Queues"/>
+      <dependency id="Rhino.ServiceBus.References" version="$version$"/>
+      <dependency id="Rhino.PersistentHashTable" version="1.7.0.0"/>
+      <dependency id="Rhino.ServiceBus" version="$version$"/>
+      <dependency id="Rhino.Queues" version="2.0.0.0"/>
     </dependencies>
   </metadata>
   <files>

--- a/packaging/rhino.servicebus.spring.nuspec
+++ b/packaging/rhino.servicebus.spring.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>Rhino.ServiceBus.Spring</id>
-    <version>0.0.0</version>
+    <version>$version$</version>
     <authors>Marko Lahma</authors>
     <owners>Corey Kaylor</owners>
     <licenseUrl>https://raw.github.com/hibernating-rhinos/rhino-esb/master/license.txt</licenseUrl>
@@ -12,7 +12,7 @@
     <description>Spring integration with Rhino.ServiceBus</description>
     <tags>rhino spring servicebus bus msmq messaging cqrs</tags>
     <dependencies>
-      <dependency id="Rhino.ServiceBus"/>
+      <dependency id="Rhino.ServiceBus" version="$version$"/>
       <dependency id="Spring.Aop" version="1.3.2" />
       <dependency id="Spring.Core" version="1.3.2" />
     </dependencies>

--- a/packaging/rhino.servicebus.structuremap.nuspec
+++ b/packaging/rhino.servicebus.structuremap.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>Rhino.ServiceBus.StructureMap</id>
-    <version>0.0.0</version>
+    <version>$version$</version>
     <authors>Corey Kaylor</authors>
     <owners>Corey Kaylor</owners>
     <licenseUrl>https://raw.github.com/hibernating-rhinos/rhino-esb/master/license.txt</licenseUrl>
@@ -12,7 +12,7 @@
     <description>StructureMap integration with Rhino.ServiceBus</description>
     <tags>rhino structuremap servicebus bus msmq messaging cqrs</tags>
     <dependencies>
-      <dependency id="Rhino.ServiceBus"/>
+      <dependency id="Rhino.ServiceBus" version="$version$"/>
       <dependency id="structuremap" version="2.6.3" />
     </dependencies>
   </metadata>

--- a/packaging/rhino.servicebus.unity.nuspec
+++ b/packaging/rhino.servicebus.unity.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>Rhino.ServiceBus.Unity</id>
-    <version>0.0.0</version>
+    <version>$version$</version>
     <authors>Rene Andersen</authors>
     <owners>Corey Kaylor</owners>
     <licenseUrl>https://raw.github.com/hibernating-rhinos/rhino-esb/master/license.txt</licenseUrl>
@@ -12,7 +12,7 @@
     <description>Unity integration with Rhino.ServiceBus</description>
     <tags>rhino unity servicebus bus msmq messaging cqrs</tags>
     <dependencies>
-      <dependency id="Rhino.ServiceBus"/>
+      <dependency id="Rhino.ServiceBus" version="$version$"/>
       <dependency id="Unity" version="2.1.505.0" />
       <dependency id="Unity.Interception" version="2.1.505.0" />
     </dependencies>


### PR DESCRIPTION
With NuGet packages referenced by version numbers (and not by name only), NuGet will install the correct (matching) dependencies when instructed to install a specific (not latest) version of a package.

This change does not provide an immediate benefit, but will enable correct behavior in the future.
