### PR TITLE
Misc fixes

### DIFF
--- a/Rhino.ServiceBus.Castle/CastleBootStrapper.cs
+++ b/Rhino.ServiceBus.Castle/CastleBootStrapper.cs
@@ -78,20 +78,7 @@ namespace Rhino.ServiceBus.Castle
 
         protected virtual void RegisterConsumersFrom(Assembly assembly)
         {
-            container.Register(
-                 AllTypes
-                    .FromAssembly(assembly)
-                    .Where(type =>
-                        typeof(IMessageConsumer).IsAssignableFrom(type) &&
-                        !typeof(IOccasionalMessageConsumer).IsAssignableFrom(type) &&
-                        IsTypeAcceptableForThisBootStrapper(type)
-                    )
-                    .Configure(registration =>
-                    {
-                        registration.LifeStyle.Is(LifestyleType.Transient);
-                        ConfigureConsumer(registration);
-                    })
-                );
+            container.RegisterConsumersFrom(assembly, ConfigureConsumer);
         }
 
         protected virtual void ConfigureConsumer(ComponentRegistration registration)

--- a/Rhino.ServiceBus.Castle/CastleBootStrapper.cs
+++ b/Rhino.ServiceBus.Castle/CastleBootStrapper.cs
@@ -78,7 +78,7 @@ namespace Rhino.ServiceBus.Castle
 
         protected virtual void RegisterConsumersFrom(Assembly assembly)
         {
-            container.RegisterConsumersFrom(assembly, ConfigureConsumer);
+            container.RegisterConsumersFrom(assembly, ConfigureConsumer, IsTypeAcceptableForThisBootStrapper);
         }
 
         protected virtual void ConfigureConsumer(ComponentRegistration registration)

--- a/Rhino.ServiceBus.Tests/EndpointRouterTests.cs
+++ b/Rhino.ServiceBus.Tests/EndpointRouterTests.cs
@@ -1,6 +1,6 @@
 using System;
 using Rhino.ServiceBus.Impl;
-using Rhino.ServiceBus.Utils;
+using Rhino.ServiceBus.Util;
 using Xunit;
 
 namespace Rhino.ServiceBus.Tests
@@ -12,27 +12,27 @@ namespace Rhino.ServiceBus.Tests
         public void can_handle_localhost_consistently()
         {
             var router = new EndpointRouter();
-            var uri = new Uri("http://localhost/blahdee");
+            var uri = new Uri("http://lOcAlHoSt/blahdee");
             var normalizedUri = uri.NormalizeLocalhost();
             var routeTo = new Uri("http://remotehost/zippee");
 
             router.RemapEndpoint(uri, routeTo);
 
-            Assert.AreEqual(routeTo, router.GetRoutedEndpoint(normalizedUri).Uri);
-            Assert.AreEqual(routeTo, router.GetRoutedEndpoint(uri).Uri);
+            Assert.Equal(routeTo, router.GetRoutedEndpoint(normalizedUri).Uri);
+            Assert.Equal(routeTo, router.GetRoutedEndpoint(uri).Uri);
         }
 
         [Fact]
         public void can_handle_localhost_consistently_2()
         {
             var router = new EndpointRouter();
-            var uri = new Uri("http://localhost/blahdee");
+            var uri = new Uri("http://127.0.0.1/blahdee");
             var normalizedUri = uri.NormalizeLocalhost();
             var routeFrom = new Uri("http://remotehost/zippee");
 
             router.RemapEndpoint(routeFrom, uri);
 
-            Assert.AreEqual(normalizedUri, router.GetRoutedEndpoint(routeFrom).Uri);
+            Assert.Equal(normalizedUri, router.GetRoutedEndpoint(routeFrom).Uri);
         }
     }
 }

--- a/Rhino.ServiceBus.Tests/EndpointRouterTests.cs
+++ b/Rhino.ServiceBus.Tests/EndpointRouterTests.cs
@@ -1,0 +1,38 @@
+using System;
+using Rhino.ServiceBus.Impl;
+using Rhino.ServiceBus.Utils;
+using Xunit;
+
+namespace Rhino.ServiceBus.Tests
+{
+    public class EndpointRouterTests
+    {
+
+        [Fact]
+        public void can_handle_localhost_consistently()
+        {
+            var router = new EndpointRouter();
+            var uri = new Uri("http://localhost/blahdee");
+            var normalizedUri = uri.NormalizeLocalhost();
+            var routeTo = new Uri("http://remotehost/zippee");
+
+            router.RemapEndpoint(uri, routeTo);
+
+            Assert.AreEqual(routeTo, router.GetRoutedEndpoint(normalizedUri).Uri);
+            Assert.AreEqual(routeTo, router.GetRoutedEndpoint(uri).Uri);
+        }
+
+        [Fact]
+        public void can_handle_localhost_consistently_2()
+        {
+            var router = new EndpointRouter();
+            var uri = new Uri("http://localhost/blahdee");
+            var normalizedUri = uri.NormalizeLocalhost();
+            var routeFrom = new Uri("http://remotehost/zippee");
+
+            router.RemapEndpoint(routeFrom, uri);
+
+            Assert.AreEqual(normalizedUri, router.GetRoutedEndpoint(routeFrom).Uri);
+        }
+    }
+}

--- a/Rhino.ServiceBus.Tests/Hosting/Can_host_in_another_app_domain.cs
+++ b/Rhino.ServiceBus.Tests/Hosting/Can_host_in_another_app_domain.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using Castle.MicroKernel.Registration;
 using Castle.Windsor;
 using Castle.Windsor.Configuration.Interpreters;
+using Rhino.ServiceBus.Config;
 using Rhino.ServiceBus.Castle;
 using Rhino.ServiceBus.Hosting;
 using Rhino.ServiceBus.Impl;
@@ -34,11 +35,12 @@ namespace Rhino.ServiceBus.Tests.Hosting
         [Fact]
         public void Can_use_different_config_correctly()
         {
+            var windsorContainer = new WindsorContainer();
             var bootStrapper = new SimpleBootStrapper(windsorContainer);
             var differentConfig = new BusConfigurationSection();
             bootStrapper.UseConfiguration(differentConfig);
             bootStrapper.InitializeContainer();
-            Assert.AreEqual(differentConfig, bootStrapper.ConfigurationSectionInUse);
+            Assert.Equal(differentConfig, bootStrapper.ConfigurationSectionInUse);
         }
 
         [Fact]

--- a/Rhino.ServiceBus.Tests/Hosting/Can_host_in_another_app_domain.cs
+++ b/Rhino.ServiceBus.Tests/Hosting/Can_host_in_another_app_domain.cs
@@ -32,6 +32,16 @@ namespace Rhino.ServiceBus.Tests.Hosting
         }
 
         [Fact]
+        public void Can_use_different_config_correctly()
+        {
+            var bootStrapper = new SimpleBootStrapper(windsorContainer);
+            var differentConfig = new BusConfigurationSection();
+            bootStrapper.UseConfiguration(differentConfig);
+            bootStrapper.InitializeContainer();
+            Assert.AreEqual(differentConfig, bootStrapper.ConfigurationSectionInUse);
+        }
+
+        [Fact]
         public void Components_are_registered_using_their_full_name()
         {
             var windsorContainer = new WindsorContainer(new XmlInterpreter());
@@ -78,9 +88,16 @@ namespace Rhino.ServiceBus.Tests.Hosting
 
     public class SimpleBootStrapper : CastleBootStrapper
     {
+        public BusConfigurationSection ConfigurationSectionInUse {get ; private set;}
+
         public SimpleBootStrapper(IWindsorContainer container) : base(container)
         {
             
+        }
+
+        protected override void ConfigureBusFacility(AbstractRhinoServiceBusConfiguration configuration)
+        {
+            ConfigurationSectionInUse = configuration.ConfigurationSection;
         }
     }
 

--- a/Rhino.ServiceBus.Tests/Rhino.ServiceBus.Tests.csproj
+++ b/Rhino.ServiceBus.Tests/Rhino.ServiceBus.Tests.csproj
@@ -212,6 +212,7 @@
     <Compile Include="DataStructures\LRUSetTest.cs" />
     <Compile Include="DataStructures\HashtableTest.cs" />
     <Compile Include="DefaultReflectionTests.cs" />
+    <Compile Include="EndpointRouterTests.cs" />
     <Compile Include="FailureToProcessMessage.cs" />
     <Compile Include="CanCreateInstancesOfServiceBusFromContainer.cs" />
     <Compile Include="FlatQueuesDelayedMessages.cs" />

--- a/Rhino.ServiceBus/Endpoint.cs
+++ b/Rhino.ServiceBus/Endpoint.cs
@@ -14,7 +14,7 @@ namespace Rhino.ServiceBus
             get { return uri; }
             set 
             {
-                if (uri == null) throw new ArgumentNullException();
+                if (value == null) throw new ArgumentNullException();
                 uri = value.NormalizeLocalhost(); 
             }
         }

--- a/Rhino.ServiceBus/Endpoint.cs
+++ b/Rhino.ServiceBus/Endpoint.cs
@@ -1,4 +1,5 @@
 using System;
+using Rhino.ServiceBus.Util;
 
 namespace Rhino.ServiceBus
 {
@@ -11,19 +12,10 @@ namespace Rhino.ServiceBus
         public Uri Uri
         {
             get { return uri; }
-            set
+            set 
             {
-                if (value.Host.Equals("localhost",StringComparison.InvariantCultureIgnoreCase))
-                {
-                    uri = new UriBuilder(value)
-                    {
-                        Host = Environment.MachineName
-                    }.Uri;
-                }
-                else
-                {
-                    uri = value;
-                }
+                if (uri == null) throw new ArgumentNullException();
+                uri = value.NormalizeLocalhost(); 
             }
         }
 

--- a/Rhino.ServiceBus/Hosting/AbstractBootStrapper.cs
+++ b/Rhino.ServiceBus/Hosting/AbstractBootStrapper.cs
@@ -9,6 +9,7 @@ namespace Rhino.ServiceBus.Hosting
     public abstract class AbstractBootStrapper : IDisposable
     {
         private AbstractRhinoServiceBusConfiguration config;
+        private BusConfigurationSection busSection;
 
         public virtual IEnumerable<Assembly> Assemblies
         {
@@ -24,7 +25,7 @@ namespace Rhino.ServiceBus.Hosting
 
         public virtual void UseConfiguration(BusConfigurationSection configurationSection)
         {
-            config.UseConfiguration(configurationSection);
+            busSection = configurationSection;
         }
 
         public abstract void CreateContainer();
@@ -42,7 +43,9 @@ namespace Rhino.ServiceBus.Hosting
 
         protected virtual AbstractRhinoServiceBusConfiguration CreateConfiguration()
         {
-            return new RhinoServiceBusConfiguration();
+            var cfg = new RhinoServiceBusConfiguration();
+            if (busSection!=null) config.UseConfiguration(configurationSection);
+            return cfg;
         }
 
         protected virtual void ConfigureBusFacility(AbstractRhinoServiceBusConfiguration configuration)

--- a/Rhino.ServiceBus/Hosting/AbstractBootStrapper.cs
+++ b/Rhino.ServiceBus/Hosting/AbstractBootStrapper.cs
@@ -26,6 +26,7 @@ namespace Rhino.ServiceBus.Hosting
         public virtual void UseConfiguration(BusConfigurationSection configurationSection)
         {
             busSection = configurationSection;
+            if (config != null) config.UseConfiguration(busSection);
         }
 
         public abstract void CreateContainer();

--- a/Rhino.ServiceBus/Hosting/AbstractBootStrapper.cs
+++ b/Rhino.ServiceBus/Hosting/AbstractBootStrapper.cs
@@ -44,7 +44,7 @@ namespace Rhino.ServiceBus.Hosting
         protected virtual AbstractRhinoServiceBusConfiguration CreateConfiguration()
         {
             var cfg = new RhinoServiceBusConfiguration();
-            if (busSection!=null) config.UseConfiguration(configurationSection);
+            if (busSection!=null) cfg.UseConfiguration(busSection);
             return cfg;
         }
 

--- a/Rhino.ServiceBus/Impl/EndpointRouter.cs
+++ b/Rhino.ServiceBus/Impl/EndpointRouter.cs
@@ -1,6 +1,7 @@
 using System;
 using Rhino.ServiceBus.DataStructures;
 using Rhino.ServiceBus.Internal;
+using Rhino.ServiceBus.Util;
 
 namespace Rhino.ServiceBus.Impl
 {

--- a/Rhino.ServiceBus/Impl/EndpointRouter.cs
+++ b/Rhino.ServiceBus/Impl/EndpointRouter.cs
@@ -14,13 +14,13 @@ namespace Rhino.ServiceBus.Impl
 
         public void RemapEndpoint(Uri originalEndpoint, Uri newEndpoint)
         {
-            mapping.Write(writer => writer.Add(originalEndpoint, newEndpoint));
+            mapping.Write(writer => writer.Add(originalEndpoint.NormalizeLocalhost(), newEndpoint.NormalizeLocalhost()));
         }
 
         public Endpoint GetRoutedEndpoint(Uri endpoint)
         {
             Uri newEndpoint = null;
-            mapping.Read(reader => reader.TryGetValue(endpoint, out newEndpoint));
+            mapping.Read(reader => reader.TryGetValue(endpoint.NormalizeLocalhost(), out newEndpoint));
             return new Endpoint
             {
                 Uri = newEndpoint ?? endpoint

--- a/Rhino.ServiceBus/Util/UriExtensions.cs
+++ b/Rhino.ServiceBus/Util/UriExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using Rhino.ServiceBus.Transport;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace Rhino.ServiceBus.Util
 {
@@ -25,7 +26,7 @@ namespace Rhino.ServiceBus.Util
 
         public static Uri NormalizeLocalhost(this Uri uri)
         {
-            if (localHosts.Contains(uri.Host))
+            if (localhosts.Contains(uri.Host))
             {
                 return new UriBuilder(uri){ Host = Environment.MachineName }.Uri;
             }

--- a/Rhino.ServiceBus/Util/UriExtensions.cs
+++ b/Rhino.ServiceBus/Util/UriExtensions.cs
@@ -20,5 +20,16 @@ namespace Rhino.ServiceBus.Util
         {
             return self.AbsolutePath.Substring(1).Split('/').First();
         }
+
+        private static HashSet<string> localhosts = new HashSet<string>(new[]{"localhost","127.0.0.1"}, StringComparer.OrdinalIgnoreCase);
+
+        public static Uri NormalizeLocalhost(this Uri uri)
+        {
+            if (localHosts.Contains(uri.Host))
+            {
+                return new UriBuilder(uri){ Host = Environment.MachineName }.Uri;
+            }
+            return uri;
+        }
     }
 }


### PR DESCRIPTION
Fixes for a few things we've been bitten by recently:
- AbstractBootstrapper's UseConfiguration method failed with a NullReference exception, fixed
- Consistent handling of "localhost" urls at service startup and in the endpointrouter
  startup replaces localhost with the machine name, which then means endpointrouter entries
  for localhost don't get routed correctly.
- Castle container's component registration method moved to an extension method for use
  outside the bootstrapper
- Tests
