### PR TITLE
Register IStartable and IServiceBus as singleton in StructureMap

### DIFF
--- a/Rhino.ServiceBus.StructureMap/StructureMapBuilder.cs
+++ b/Rhino.ServiceBus.StructureMap/StructureMapBuilder.cs
@@ -85,6 +85,8 @@ namespace Rhino.ServiceBus.StructureMap
                     .Ctor<MessageOwner[]>().Is(busConfig.MessageOwners.ToArray());
                 c.Forward<IStartableServiceBus, IStartable>();
                 c.Forward<IStartableServiceBus, IServiceBus>();
+                c.For<IStartable>().Singleton();
+                c.For<IServiceBus>().Singleton();
             });
         }
 


### PR DESCRIPTION
StructureMap's Forward method doesn't apply the singleton configuration to the additional interfaces that were registered.  Normally you wouldn't notice this because StructureMap still returns the singleton instance when injecting IServiceBus, but when using a nested container it disposes the instance when the container is disposed.
