### PR TITLE
Un-pin Autofac dependency

### DIFF
--- a/packaging/rhino.servicebus.autofac.nuspec
+++ b/packaging/rhino.servicebus.autofac.nuspec
@@ -13,7 +13,7 @@
     <tags>rhino autofac servicebus bus msmq messaging cqrs</tags>
     <dependencies>
       <dependency id="Rhino.ServiceBus" version="$version$"/>
-      <dependency id="Autofac" version="[2.6.3.862]"/>
+      <dependency id="Autofac" version="2.6.3.862"/>
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
So that we can actually build projects depending on `Rhino.ServiceBus.Autofac` 3.1.1.0 (current stable).

ATM .net 4.0 apps require Autofac 3.0+, but the current nuspec does not allow this dependency, since it is fixed on 2.6.3.862. IMO it should not be fixed - 2.6.3.862 is still required for .net 3.5, but for .net 4.0 we (probably?) should be allowed to install Autofac 3.0+

Please review carefully; I don't know _why_ this dependency was fixed to 2.6.3.862 in the first place. I do see that the library was updated in d05d9f54189f0bd7e4e6c310d1ccde6a793ef6a7, without updating the dependency in the nuspec file.

For now, I can work around this by installing `Rhino.ServiceBus.Autofac` 3.1.0.0
#### Reproduce & Some Details

Starting a new console application, running 

```
Install-Package Rhino.ServiceBus.Autofac -version 3.1.1.0
```

and adding

```
public class ClientBootStrapper : Rhino.ServiceBus.Autofac.AutofacBootStrapper {}
```

Results in a failing build:

```
Error   1   Assembly 'Rhino.ServiceBus.Autofac, Version=3.1.1.0, Culture=neutral, PublicKeyToken=0b3305902db7183f' uses 'Autofac, Version=3.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da' which has a higher version than referenced assembly 'Autofac, Version=2.6.3.862, Culture=neutral, PublicKeyToken=17863af14b0044da' c:\dev\rhino-esb-autofac\packages\Rhino.ServiceBus.Autofac.3.1.1.0\lib\4.0\Rhino.ServiceBus.Autofac.dll rhino-esb-autofac
```

Since the nuget dependency currently is fixed on 2.6.3.862, we cannot update it to 3.0+.

Current workaround is to install `Rhino.ServiceBus.Autofac` 3.1.1.0.
