### PR TITLE
Ensure open generic handlers are discoverable when using Autofac

### DIFF
--- a/Rhino.ServiceBus.Autofac/AutofacServiceLocator.cs
+++ b/Rhino.ServiceBus.Autofac/AutofacServiceLocator.cs
@@ -39,6 +39,13 @@ namespace Rhino.ServiceBus
 
         public IEnumerable<IHandler> GetAllHandlersFor(Type type)
         {
+            // Autofac lazily registers closing types upon request - without this check, available 
+            // open generic types will not be found by the select statement below
+            if (!CanResolve(type))
+            {
+                return Enumerable.Empty<IHandler>();
+            }
+
             var services = container.ComponentRegistry.Registrations
               .SelectMany(r => r.Services.OfType<TypedService>())
               .Where(pService => type.IsAssignableFrom(pService.ServiceType));


### PR DESCRIPTION
This change enables the use of open generic handler types when using Autofac.

`IMessageConsumer` _is not_ registered for these types, so the message types will not be registered in `DefaultServiceBus.AutomaticallySubscribeConsumerMessages`, but they can be registered manually.
