### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 Rhino Service Bus - A developer friendly service bus for .NET
 =====================================================
 
-##DESCRIPTION
+## DESCRIPTION
 
 Rhino Service Bus is a messaging framework that supports transactional, durable, reliable, distributed, asynchronous messaging.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
